### PR TITLE
Audio settings enhancements

### DIFF
--- a/elm.json
+++ b/elm.json
@@ -14,9 +14,11 @@
             "elm/svg": "1.0.1",
             "elm-community/html-extra": "3.4.0",
             "elm-community/list-extra": "8.7.0",
-            "elm-community/maybe-extra": "5.3.0"
+            "elm-community/maybe-extra": "5.3.0",
+            "elm-community/string-extra": "4.0.1"
         },
         "indirect": {
+            "elm/regex": "1.0.0",
             "elm/time": "1.0.0",
             "elm/url": "1.0.0",
             "elm/virtual-dom": "1.0.3"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "type": "module",
   "scripts": {
     "build": "rm -rf public && tsc && npx @tailwindcss/cli -i src/main.css -o public/dist/main.css --minify && npx elm-watch make --optimize && node scripts/applyHash.mjs",
-    "clean": "rm -rf public && mkdir public && cp src/index.html public/",
+    "clean": "rm -rf public elm-stuff && mkdir public && cp src/index.html public/",
     "codegen": "node codegen/run.js",
     "dev": "npm run clean && concurrently \"npm run tailwind\" \"npm run start\" \"npx elm-watch hot\" \"npm run watch\"",
     "start": "node server.cjs",

--- a/src/AudioSettings.elm
+++ b/src/AudioSettings.elm
@@ -1,0 +1,22 @@
+module AudioSettings exposing (AudioSettings, Register(..), adjustPitch)
+
+
+type alias AudioSettings =
+    { gain : Float
+    , register : Register
+    }
+
+
+type Register
+    = Treble
+    | Bass
+
+
+adjustPitch : Register -> Float -> Float
+adjustPitch register pitch =
+    case register of
+        Treble ->
+            pitch
+
+        Bass ->
+            pitch / 2

--- a/src/AudioSettings.elm
+++ b/src/AudioSettings.elm
@@ -1,22 +1,19 @@
-module AudioSettings exposing (AudioSettings, Register(..), adjustPitch)
+module AudioSettings exposing (AudioSettings, defaultAudioSettings)
+
+import Byzantine.Degree exposing (Degree(..))
+import Byzantine.Pitch exposing (PitchStandard(..), Register(..))
 
 
 type alias AudioSettings =
     { gain : Float
+    , pitchStandard : PitchStandard
     , register : Register
     }
 
 
-type Register
-    = Treble
-    | Bass
-
-
-adjustPitch : Register -> Float -> Float
-adjustPitch register pitch =
-    case register of
-        Treble ->
-            pitch
-
-        Bass ->
-            pitch / 2
+defaultAudioSettings : AudioSettings
+defaultAudioSettings =
+    { gain = 0.3
+    , pitchStandard = Ni256
+    , register = Treble
+    }

--- a/src/Byzantine/Pitch.elm
+++ b/src/Byzantine/Pitch.elm
@@ -1,6 +1,6 @@
 module Byzantine.Pitch exposing
     ( pitchPosition, pitchPositions
-    , frequency
+    , PitchStandard(..), Register(..), frequency
     , Interval, intervalsFrom
     )
 
@@ -19,7 +19,7 @@ attractions and inflections.
 
 # Frequency
 
-@docs frequency
+@docs PitchStandard, Register, frequency
 
 
 # Intervals
@@ -91,15 +91,46 @@ hardChromaticPitchPositions =
 -- FREQUENCY
 
 
-{-| Frequency relative to a fixed pitch of 384 Hz for Di.
+{-| Pitch standard for frequency. Ni = 256 Hz is the default standard, but the
+slightly higher Ke = 440 Hz is available to align with the A440 western
+classical standard.
 -}
-frequency : Scale -> Degree -> Float
-frequency scale degree =
+type PitchStandard
+    = Ni256
+    | Ke440
+
+
+type Register
+    = Treble
+    | Bass
+
+
+{-| Frequency relative to a fixed pitch for Di, according to the given pitch
+standard and register.
+-}
+frequency : PitchStandard -> Register -> Scale -> Degree -> Float
+frequency pitchStandard register scale degree =
     let
         position =
             pitchPosition scale degree - 84 |> toFloat
+
+        di =
+            case pitchStandard of
+                Ni256 ->
+                    384.0
+
+                Ke440 ->
+                    391.995
+
+        registerFactor =
+            case register of
+                Treble ->
+                    1.0
+
+                Bass ->
+                    0.5
     in
-    2 ^ (position / 72) * 384
+    2 ^ (position / 72) * di * registerFactor
 
 
 

--- a/src/Model.elm
+++ b/src/Model.elm
@@ -1,6 +1,6 @@
 module Model exposing (Modal(..), Model, initialModel, modalOpen, modalToString)
 
-import AudioSettings exposing (AudioSettings, Register(..))
+import AudioSettings exposing (AudioSettings)
 import Browser.Dom as Dom
 import Byzantine.Degree exposing (Degree)
 import Byzantine.Scale exposing (Scale(..))
@@ -21,10 +21,7 @@ type alias Model =
 
 initialModel : Model
 initialModel =
-    { audioSettings =
-        { gain = 0.3
-        , register = Treble
-        }
+    { audioSettings = AudioSettings.defaultAudioSettings
     , scale = Diatonic
     , showSpacing = False
     , modal = NoModal

--- a/src/Model.elm
+++ b/src/Model.elm
@@ -1,5 +1,6 @@
-module Model exposing (AudioSettings, Modal(..), Model, Register(..), adjustPitch, initialModel, modalOpen, modalToString)
+module Model exposing (Modal(..), Model, initialModel, modalOpen, modalToString)
 
+import AudioSettings exposing (AudioSettings, Register(..))
 import Browser.Dom as Dom
 import Byzantine.Degree exposing (Degree)
 import Byzantine.Scale exposing (Scale(..))
@@ -16,27 +17,6 @@ type alias Model =
     , proposedMovement : Movement
     , viewport : Dom.Viewport
     }
-
-
-type alias AudioSettings =
-    { gain : Float
-    , register : Register
-    }
-
-
-type Register
-    = Treble
-    | Bass
-
-
-adjustPitch : Register -> Float -> Float
-adjustPitch register pitch =
-    case register of
-        Treble ->
-            pitch
-
-        Bass ->
-            pitch / 2
 
 
 initialModel : Model

--- a/src/RadioFieldset.elm
+++ b/src/RadioFieldset.elm
@@ -1,0 +1,52 @@
+module RadioFieldset exposing (Config, view)
+
+import Html exposing (Html, div, fieldset, input, label, legend, text)
+import Html.Attributes as Attr exposing (checked, class, type_)
+import Html.Events exposing (onClick)
+import Html.Lazy
+import String.Extra exposing (dasherize)
+
+
+type alias Config a msg =
+    { itemToString : a -> String
+    , legendText : String
+    , onSelect : a -> msg
+    , options : List a
+    , selected : a
+    }
+
+
+view : Config a msg -> Html msg
+view config =
+    Html.Lazy.lazy
+        (\config_ ->
+            List.map (radioOption config_) config_.options
+                |> (::) (legend [ class "px-1" ] [ text config_.legendText ])
+                |> fieldset [ class "border border-gray-300 rounded-sm px-2 pb-1" ]
+        )
+        config
+
+
+radioOption : Config a msg -> a -> Html msg
+radioOption config option =
+    let
+        itemName =
+            config.itemToString option
+
+        id =
+            "radio-option-" ++ dasherize itemName
+    in
+    div []
+        [ input
+            [ type_ "radio"
+            , Attr.name ("radio-" ++ dasherize config.legendText)
+            , Attr.id id
+            , class "cursor-pointer m-2"
+            , checked (config.selected == option)
+            , onClick (config.onSelect option)
+            ]
+            []
+        , label
+            [ Attr.for id, class "cursor-pointer" ]
+            [ text (config.itemToString option) ]
+        ]

--- a/src/RadioFieldset.elm
+++ b/src/RadioFieldset.elm
@@ -13,6 +13,7 @@ type alias Config a msg =
     , onSelect : a -> msg
     , options : List a
     , selected : a
+    , viewItem : Maybe (a -> Html msg)
     }
 
 
@@ -22,7 +23,7 @@ view config =
         (\config_ ->
             List.map (radioOption config_) config_.options
                 |> (::) (legend [ class "px-1" ] [ text config_.legendText ])
-                |> fieldset [ class "border border-gray-300 rounded-sm px-2 pb-1" ]
+                |> fieldset [ class "border border-gray-300 rounded-sm px-2 pb-1 mb-2" ]
         )
         config
 
@@ -48,5 +49,11 @@ radioOption config option =
             []
         , label
             [ Attr.for id, class "cursor-pointer" ]
-            [ text (config.itemToString option) ]
+            [ case config.viewItem of
+                Just viewItem ->
+                    viewItem option
+
+                Nothing ->
+                    text (config.itemToString option)
+            ]
         ]

--- a/src/RadioFieldset.elm
+++ b/src/RadioFieldset.elm
@@ -37,7 +37,7 @@ radioOption config option =
         id =
             "radio-option-" ++ dasherize itemName
     in
-    div []
+    div [ class "flex flex-row items-center" ]
         [ input
             [ type_ "radio"
             , Attr.name ("radio-" ++ dasherize config.legendText)

--- a/src/Update.elm
+++ b/src/Update.elm
@@ -1,10 +1,11 @@
 module Update exposing (Msg(..), update)
 
+import AudioSettings exposing (Register)
 import Browser.Dom as Dom
 import Byzantine.Degree as Degree exposing (Degree(..))
 import Byzantine.Scale exposing (Scale)
 import Maybe.Extra as Maybe
-import Model exposing (Modal, Model, Register(..))
+import Model exposing (Modal, Model)
 import Movement exposing (Movement)
 import Platform.Cmd as Cmd
 import Task

--- a/src/Update.elm
+++ b/src/Update.elm
@@ -1,8 +1,8 @@
 module Update exposing (Msg(..), update)
 
-import AudioSettings exposing (Register)
 import Browser.Dom as Dom
 import Byzantine.Degree as Degree exposing (Degree(..))
+import Byzantine.Pitch exposing (PitchStandard, Register)
 import Byzantine.Scale exposing (Scale)
 import Maybe.Extra as Maybe
 import Model exposing (Modal, Model)
@@ -21,6 +21,7 @@ type Msg
     | SelectPitch (Maybe Degree) (Maybe Movement)
     | SelectProposedMovement Movement
     | SetGain Float
+    | SetPitchStandard PitchStandard
     | SetRegister Register
     | SetScale Scale
     | ToggleMenu
@@ -75,6 +76,15 @@ update msg model =
                     model.audioSettings
             in
             ( { model | audioSettings = { audioSettings | gain = clamp 0 1 gain } }
+            , Cmd.none
+            )
+
+        SetPitchStandard pitchStandard ->
+            let
+                audioSettings =
+                    model.audioSettings
+            in
+            ( { model | audioSettings = { audioSettings | pitchStandard = pitchStandard } }
             , Cmd.none
             )
 

--- a/src/View.elm
+++ b/src/View.elm
@@ -226,7 +226,7 @@ viewPitchStandard pitchStandard =
         ( martyria, frequency ) =
             case pitchStandard of
                 Ni256 ->
-                    ( Martyria.view (Martyria.for Diatonic Ni)
+                    ( Martyria.for Diatonic Ni |> Martyria.view
                     , " = 256 Hz"
                     )
 

--- a/src/View.elm
+++ b/src/View.elm
@@ -9,8 +9,8 @@ import Byzantine.Martyria as Martyria
 import Byzantine.Pitch as Pitch exposing (Interval)
 import Byzantine.Scale as Scale exposing (Scale(..))
 import Copy
-import Html exposing (Html, button, div, fieldset, h1, h2, input, label, legend, main_, p, span, text)
-import Html.Attributes as Attr exposing (checked, class, classList, for, id, style, type_)
+import Html exposing (Html, button, div, h1, h2, input, main_, p, span, text)
+import Html.Attributes as Attr exposing (class, classList, id, style, type_)
 import Html.Attributes.Extra as Attr
 import Html.Events exposing (onClick, onFocus, onInput, onMouseEnter, onMouseLeave)
 import Html.Extra exposing (viewIf, viewMaybe)
@@ -20,6 +20,7 @@ import List.Extra as List
 import Maybe.Extra as Maybe
 import Model exposing (AudioSettings, Modal(..), Model, Register(..), adjustPitch)
 import Movement exposing (Movement(..))
+import RadioFieldset
 import Update exposing (Msg(..))
 
 
@@ -150,7 +151,7 @@ viewModal model =
             Html.node "dialog"
                 [ class "fixed inset-1/4 top-24 w-3/4 md:w-1/2 z-10"
                 , class "flex flex-col"
-                , class "bg-white"
+                , class "p-6 bg-white"
                 , class "border border-gray-300 rounded-md shadow-md font-serif"
                 , id "modal"
                 ]
@@ -180,46 +181,25 @@ modalContent model =
             settings model
 
 
-{-| TODO: create a radio input helper if this pattern comes up in more places.
--}
 settings : Model -> Html Msg
 settings model =
-    let
-        radioOption register =
-            let
-                registerName =
+    div []
+        [ spacingButton model.showSpacing
+            |> viewIf debuggingLayout
+        , RadioFieldset.view
+            { itemToString =
+                \register ->
                     case register of
                         Treble ->
                             "Treble"
 
                         Bass ->
                             "Bass"
-            in
-            div []
-                [ input
-                    [ type_ "radio"
-                    , Attr.name "register"
-                    , onClick (SetRegister register)
-                    , class "cursor-pointer m-2"
-                    , id <| "select" ++ registerName
-                    , checked (model.audioSettings.register == register)
-                    ]
-                    []
-                , label
-                    [ for <| "select" ++ registerName
-                    , class "cursor-pointer"
-                    ]
-                    [ text registerName ]
-                ]
-    in
-    div []
-        [ spacingButton model.showSpacing
-            |> viewIf debuggingLayout
-        , fieldset []
-            [ legend [] [ text "Register" ]
-            , radioOption Treble
-            , radioOption Bass
-            ]
+            , legendText = "Register"
+            , onSelect = SetRegister
+            , options = [ Treble, Bass ]
+            , selected = model.audioSettings.register
+            }
         , gainInput model.audioSettings
         ]
 
@@ -437,32 +417,13 @@ spacingButton showSpacing =
 
 selectScale : Model -> Html Msg
 selectScale model =
-    let
-        radioOption scale =
-            let
-                scaleName =
-                    Scale.name scale
-            in
-            div []
-                [ input
-                    [ type_ "radio"
-                    , Attr.name "scale"
-                    , onClick (SetScale scale)
-                    , class "cursor-pointer m-2"
-                    , id <| "select" ++ scaleName
-                    , checked (model.scale == scale)
-                    ]
-                    []
-                , label
-                    [ for <| "select" ++ scaleName
-                    , class "cursor-pointer"
-                    ]
-                    [ text scaleName ]
-                ]
-    in
-    fieldset [] <|
-        legend [] [ text "Select scale:" ]
-            :: List.map radioOption Scale.all
+    RadioFieldset.view
+        { itemToString = Scale.name
+        , legendText = "Select Scale"
+        , onSelect = SetScale
+        , options = Scale.all
+        , selected = model.scale
+        }
 
 
 viewCurrentPitch : Maybe Degree -> Html Msg

--- a/src/View.elm
+++ b/src/View.elm
@@ -1,5 +1,6 @@
 module View exposing (view)
 
+import AudioSettings exposing (AudioSettings, Register(..), adjustPitch)
 import Browser.Dom as Dom
 import Byzantine.ByzHtml.Interval as Interval
 import Byzantine.ByzHtml.Martyria as Martyria
@@ -18,7 +19,7 @@ import Icons
 import Json.Decode exposing (Decoder)
 import List.Extra as List
 import Maybe.Extra as Maybe
-import Model exposing (AudioSettings, Modal(..), Model, Register(..), adjustPitch)
+import Model exposing (Modal(..), Model)
 import Movement exposing (Movement(..))
 import RadioFieldset
 import Update exposing (Msg(..))

--- a/src/View.elm
+++ b/src/View.elm
@@ -199,6 +199,7 @@ settings model =
             , onSelect = SetRegister
             , options = [ Treble, Bass ]
             , selected = model.audioSettings.register
+            , viewItem = Nothing
             }
         , RadioFieldset.view
             { itemToString =
@@ -213,8 +214,30 @@ settings model =
             , onSelect = SetPitchStandard
             , options = [ Ni256, Ke440 ]
             , selected = model.audioSettings.pitchStandard
+            , viewItem = Just viewPitchStandard
             }
         , gainInput model.audioSettings
+        ]
+
+
+viewPitchStandard : PitchStandard -> Html msg
+viewPitchStandard pitchStandard =
+    let
+        ( martyria, frequency ) =
+            case pitchStandard of
+                Ni256 ->
+                    ( Martyria.view (Martyria.for Diatonic Ni)
+                    , " = 256 Hz"
+                    )
+
+                Ke440 ->
+                    ( Martyria.for Diatonic Ke |> Martyria.view
+                    , " = 440 Hz"
+                    )
+    in
+    span [ class "mb-1" ]
+        [ span [ class "text-xl relative bottom-1.5" ] [ martyria ]
+        , text frequency
         ]
 
 
@@ -437,6 +460,7 @@ selectScale model =
         , onSelect = SetScale
         , options = Scale.all
         , selected = model.scale
+        , viewItem = Nothing
         }
 
 

--- a/src/View.elm
+++ b/src/View.elm
@@ -183,7 +183,7 @@ modalContent model =
 
 settings : Model -> Html Msg
 settings model =
-    div []
+    div [ class "flex flex-col gap-2" ]
         [ spacingButton model.showSpacing
             |> viewIf debuggingLayout
         , RadioFieldset.view
@@ -235,7 +235,7 @@ viewPitchStandard pitchStandard =
                     , " = 440 Hz"
                     )
     in
-    span [ class "mb-1" ]
+    div [ class "mb-1" ]
         [ span [ class "text-xl relative bottom-1.5" ] [ martyria ]
         , text frequency
         ]

--- a/src/View.elm
+++ b/src/View.elm
@@ -1,13 +1,13 @@
 module View exposing (view)
 
-import AudioSettings exposing (AudioSettings, Register(..), adjustPitch)
+import AudioSettings exposing (AudioSettings)
 import Browser.Dom as Dom
 import Byzantine.ByzHtml.Interval as Interval
 import Byzantine.ByzHtml.Martyria as Martyria
 import Byzantine.Degree as Degree exposing (Degree(..))
 import Byzantine.IntervalCharacter exposing (..)
 import Byzantine.Martyria as Martyria
-import Byzantine.Pitch as Pitch exposing (Interval)
+import Byzantine.Pitch as Pitch exposing (Interval, PitchStandard(..), Register(..))
 import Byzantine.Scale as Scale exposing (Scale(..))
 import Copy
 import Html exposing (Html, button, div, h1, h2, input, main_, p, span, text)
@@ -85,8 +85,7 @@ audio model =
                 Attr.empty
 
             Just pitch ->
-                Pitch.frequency model.scale pitch
-                    |> adjustPitch model.audioSettings.register
+                Pitch.frequency model.audioSettings.pitchStandard model.audioSettings.register model.scale pitch
                     |> String.fromFloat
                     |> Attr.attribute "ison"
         ]
@@ -200,6 +199,20 @@ settings model =
             , onSelect = SetRegister
             , options = [ Treble, Bass ]
             , selected = model.audioSettings.register
+            }
+        , RadioFieldset.view
+            { itemToString =
+                \pitchStandard ->
+                    case pitchStandard of
+                        Ni256 ->
+                            "Ni256"
+
+                        Ke440 ->
+                            "Ke440"
+            , legendText = "Pitch Standard"
+            , onSelect = SetPitchStandard
+            , options = [ Ni256, Ke440 ]
+            , selected = model.audioSettings.pitchStandard
             }
         , gainInput model.audioSettings
         ]


### PR DESCRIPTION
- Pulls `AudioSettings` into own module
- Moves `Register` to `Byzantine.Pitch` module
- Adds `PitchStandard` type to `Byzantine.Pitch` module
- Creates a shared `RadioFieldset` module for a standardized radio button component