### PR TITLE
Rewrite Layout

### DIFF
--- a/elm.json
+++ b/elm.json
@@ -15,7 +15,8 @@
             "elm-community/html-extra": "3.4.0",
             "elm-community/list-extra": "8.7.0",
             "elm-community/maybe-extra": "5.3.0",
-            "elm-community/string-extra": "4.0.1"
+            "elm-community/string-extra": "4.0.1",
+            "myrho/elm-round": "1.0.5"
         },
         "indirect": {
             "elm/regex": "1.0.0",

--- a/src/Byzantine/ByzHtml/Martyria.elm
+++ b/src/Byzantine/ByzHtml/Martyria.elm
@@ -1,4 +1,4 @@
-module Byzantine.ByzHtml.Martyria exposing (view)
+module Byzantine.ByzHtml.Martyria exposing (view, viewWithAttributes)
 
 import Byzantine.Degree exposing (Degree(..))
 import Byzantine.Martyria as Martyria exposing (Martyria, ModalSignature(..))
@@ -8,15 +8,20 @@ import Html exposing (Html)
 
 view : Martyria -> Html msg
 view martyria =
+    viewWithAttributes [] martyria
+
+
+viewWithAttributes : List (Html.Attribute msg) -> Martyria -> Html msg
+viewWithAttributes attributes martyria =
     let
         ( degree, signature ) =
             Martyria.unwrap martyria
     in
     if positionDegreeBelow degree then
-        Html.node "x-martyria" [] [ viewSignature False signature, viewDegree degree ]
+        Html.node "x-martyria" attributes [ viewSignature False signature, viewDegree degree ]
 
     else
-        Html.node "x-martyria" [] [ viewDegree degree, viewSignature True signature ]
+        Html.node "x-martyria" attributes [ viewDegree degree, viewSignature True signature ]
 
 
 positionDegreeBelow : Degree -> Bool

--- a/src/Byzantine/Degree.elm
+++ b/src/Byzantine/Degree.elm
@@ -1,4 +1,4 @@
-module Byzantine.Degree exposing (Degree(..), baseOctave, gamut, getInterval, indexOf, range, step, text, toString, toStringGreek)
+module Byzantine.Degree exposing (Degree(..), baseOctave, gamut, gamutList, getInterval, indexOf, range, step, text, toString, toStringGreek)
 
 import Array exposing (Array)
 import Byzantine.Scale exposing (Scale(..))
@@ -146,7 +146,12 @@ text degree =
 
 gamut : Array Degree
 gamut =
-    Array.fromList [ GA, DI, KE, Zo, Ni, Pa, Bou, Ga, Di, Ke, Zo_, Ni_, Pa_, Bou_, Ga_ ]
+    Array.fromList gamutList
+
+
+gamutList : List Degree
+gamutList =
+    [ GA, DI, KE, Zo, Ni, Pa, Bou, Ga, Di, Ke, Zo_, Ni_, Pa_, Bou_, Ga_ ]
 
 
 {-| List of steps from `from` to `to`, inclusive.

--- a/src/Byzantine/Degree.elm
+++ b/src/Byzantine/Degree.elm
@@ -1,4 +1,4 @@
-module Byzantine.Degree exposing (Degree(..), baseOctave, gamut, getInterval, indexOf, range, step, text, toString)
+module Byzantine.Degree exposing (Degree(..), baseOctave, gamut, getInterval, indexOf, range, step, text, toString, toStringGreek)
 
 import Array exposing (Array)
 import Byzantine.Scale exposing (Scale(..))
@@ -83,58 +83,65 @@ toString degree =
             "Ga_"
 
 
+{-| Greek text representation of the degree. No differentiation for different
+octaves.
+-}
+toStringGreek : Degree -> String
+toStringGreek degree =
+    case degree of
+        GA ->
+            "Γα"
+
+        DI ->
+            "Δι"
+
+        KE ->
+            "Κε"
+
+        Zo ->
+            "Ζω"
+
+        Ni ->
+            "Νη"
+
+        Pa ->
+            "Πα"
+
+        Bou ->
+            "Βου"
+
+        Ga ->
+            "Γα"
+
+        Di ->
+            "Δι"
+
+        Ke ->
+            "Κε"
+
+        Zo_ ->
+            "Ζω"
+
+        Ni_ ->
+            "Νη"
+
+        Pa_ ->
+            "Πα"
+
+        Bou_ ->
+            "Βου"
+
+        Ga_ ->
+            "Γα"
+
+
 {-| Greek text representation of the degree, e.g., `<span
 class="font-greek">Δι</span>`. No differentiation for different octaves.
 -}
 text : Degree -> Html msg
 text degree =
     Html.span [ class "font-greek" ]
-        [ case degree of
-            GA ->
-                Html.text "Γα"
-
-            DI ->
-                Html.text "Δι"
-
-            KE ->
-                Html.text "Κε"
-
-            Zo ->
-                Html.text "Ζω"
-
-            Ni ->
-                Html.text "Νη"
-
-            Pa ->
-                Html.text "Πα"
-
-            Bou ->
-                Html.text "Βου"
-
-            Ga ->
-                Html.text "Γα"
-
-            Di ->
-                Html.text "Δι"
-
-            Ke ->
-                Html.text "Κε"
-
-            Zo_ ->
-                Html.text "Ζω"
-
-            Ni_ ->
-                Html.text "Νη"
-
-            Pa_ ->
-                Html.text "Πα"
-
-            Bou_ ->
-                Html.text "Βου"
-
-            Ga_ ->
-                Html.text "Γα"
-        ]
+        [ Html.text (toStringGreek degree) ]
 
 
 gamut : Array Degree

--- a/src/Byzantine/Pitch.elm
+++ b/src/Byzantine/Pitch.elm
@@ -1,7 +1,7 @@
 module Byzantine.Pitch exposing
     ( pitchPosition, pitchPositions
     , PitchStandard(..), Register(..), frequency
-    , Interval, intervalsFrom
+    , Interval, intervals, intervalsFrom
     )
 
 {-| Pitch positions and derived intervals. Di is fixed at 84.
@@ -24,7 +24,7 @@ attractions and inflections.
 
 # Intervals
 
-@docs Interval, intervalsFrom
+@docs Interval, intervals, intervalsFrom
 
 -}
 
@@ -152,16 +152,21 @@ getInterval scale from to =
     }
 
 
+intervals : Scale -> List Interval
+intervals scale =
+    intervalsHelper scale Degree.gamutList
+
+
 intervalsFrom : Scale -> Degree -> Degree -> List Interval
 intervalsFrom scale lower upper =
-    let
-        go degrees =
-            case degrees of
-                a :: b :: rest ->
-                    getInterval scale a b :: go (b :: rest)
+    intervalsHelper scale (Degree.range lower upper)
 
-                _ ->
-                    []
-    in
-    Degree.range lower upper
-        |> go
+
+intervalsHelper : Scale -> List Degree -> List Interval
+intervalsHelper scale degrees =
+    case degrees of
+        a :: b :: rest ->
+            getInterval scale a b :: intervalsHelper scale (b :: rest)
+
+        _ ->
+            []

--- a/src/Main.elm
+++ b/src/Main.elm
@@ -26,5 +26,8 @@ main =
 init : () -> ( Model, Cmd Msg )
 init _ =
     ( Model.initialModel
-    , Task.perform GotViewport Dom.getViewport
+    , Cmd.batch
+        [ Task.perform GotViewport Dom.getViewport
+        , Task.attempt GotViewportOfPitchSpace (Dom.getViewportOf "pitch-space")
+        ]
     )

--- a/src/Main.elm
+++ b/src/Main.elm
@@ -26,8 +26,5 @@ main =
 init : () -> ( Model, Cmd Msg )
 init _ =
     ( Model.initialModel
-    , Cmd.batch
-        [ Task.perform GotViewport Dom.getViewport
-        , Task.attempt GotViewportOfPitchSpace (Dom.getViewportOf "pitch-space")
-        ]
+    , Task.perform GotViewport Dom.getViewport
     )

--- a/src/Model.elm
+++ b/src/Model.elm
@@ -1,6 +1,6 @@
 module Model exposing
     ( Model, initialModel
-    , LayoutSelection(..), Layout(..), layoutFor, layoutString
+    , LayoutData, LayoutSelection(..), Layout(..), layoutFor, layoutString
     , Modal(..), modalOpen, modalToString
     )
 
@@ -14,7 +14,7 @@ module Model exposing
 
 # Layout
 
-@docs LayoutSelection, Layout, layoutFor, layoutString
+@docs LayoutData, LayoutSelection, Layout, layoutFor, layoutString
 
 
 # Modal
@@ -33,13 +33,12 @@ import Movement exposing (Movement(..))
 type alias Model =
     { audioSettings : AudioSettings
     , currentPitch : Maybe Degree
-    , layoutSelection : LayoutSelection
+    , layout : LayoutData
     , menuOpen : Bool
     , modal : Modal
     , proposedMovement : Movement
     , scale : Scale
     , showSpacing : Bool
-    , viewport : Dom.Viewport
     }
 
 
@@ -47,21 +46,35 @@ initialModel : Model
 initialModel =
     { audioSettings = AudioSettings.defaultAudioSettings
     , currentPitch = Nothing
-    , layoutSelection = Auto
+    , layout =
+        { layoutSelection = Auto
+        , viewport = emptyViewport
+        , viewportOfPitchSpace = emptyViewport
+        }
     , menuOpen = False
     , modal = NoModal
     , proposedMovement = None
     , scale = Diatonic
     , showSpacing = False
-    , viewport =
-        { scene = { width = 0, height = 0 }
-        , viewport = { x = 0, y = 0, width = 0, height = 0 }
-        }
+    }
+
+
+emptyViewport : Dom.Viewport
+emptyViewport =
+    { scene = { width = 0, height = 0 }
+    , viewport = { x = 0, y = 0, width = 0, height = 0 }
     }
 
 
 
 -- LAYOUT
+
+
+type alias LayoutData =
+    { layoutSelection : LayoutSelection
+    , viewport : Dom.Viewport
+    , viewportOfPitchSpace : Dom.Viewport
+    }
 
 
 type LayoutSelection
@@ -78,7 +91,7 @@ type Layout
 should only kick into landscape if the height is sufficiently small, or perhaps
 if the ratio is beneath some threshold.
 -}
-layoutFor : Model -> Layout
+layoutFor : LayoutData -> Layout
 layoutFor { layoutSelection, viewport } =
     case layoutSelection of
         Auto ->

--- a/src/Model.elm
+++ b/src/Model.elm
@@ -101,23 +101,30 @@ type LayoutSelection
 
 
 type Layout
-    = Portrait
-    | Landscape
+    = Vertical
+    | Horizontal
 
 
-{-| The specifics here will need work. Portrait should be the default, and Auto
-should only kick into landscape if the height is sufficiently small, or perhaps
-if the ratio is beneath some threshold.
+{-| For Auto layout, Vertical is the default. Only when the screen is relatively
+short _and_ significantly wider than it is tall should the layout switch to
+Horizontal.
 -}
 layoutFor : LayoutData -> Layout
 layoutFor { layoutSelection, viewport } =
     case layoutSelection of
         Auto ->
-            -- TODO: implement.
-            Portrait
+            let
+                ratio =
+                    viewport.viewport.height / viewport.viewport.width
+            in
+            if viewport.viewport.height < 800 && ratio < 2.2 then
+                Horizontal
 
-        Manual layout_ ->
-            layout_
+            else
+                Vertical
+
+        Manual layout ->
+            layout
 
 
 layoutString : LayoutSelection -> String
@@ -126,11 +133,11 @@ layoutString layoutSelection =
         Auto ->
             "Auto"
 
-        Manual Portrait ->
-            "Portrait"
+        Manual Vertical ->
+            "Vertical"
 
-        Manual Landscape ->
-            "Landscape"
+        Manual Horizontal ->
+            "Horizontal"
 
 
 

--- a/src/Model.elm
+++ b/src/Model.elm
@@ -1,4 +1,27 @@
-module Model exposing (Modal(..), Model, initialModel, modalOpen, modalToString)
+module Model exposing
+    ( Model, initialModel
+    , LayoutSelection(..), Layout(..), layout, layoutString
+    , Modal(..), modalOpen, modalToString
+    )
+
+{-|
+
+
+# Model
+
+@docs Model, initialModel
+
+
+# Layout
+
+@docs LayoutSelection, Layout, layout, layoutString
+
+
+# Modal
+
+@docs Modal, modalOpen, modalToString
+
+-}
 
 import AudioSettings exposing (AudioSettings)
 import Browser.Dom as Dom
@@ -9,12 +32,13 @@ import Movement exposing (Movement(..))
 
 type alias Model =
     { audioSettings : AudioSettings
+    , currentPitch : Maybe Degree
+    , layoutSelection : LayoutSelection
+    , menuOpen : Bool
+    , modal : Modal
+    , proposedMovement : Movement
     , scale : Scale
     , showSpacing : Bool
-    , modal : Modal
-    , menuOpen : Bool
-    , currentPitch : Maybe Degree
-    , proposedMovement : Movement
     , viewport : Dom.Viewport
     }
 
@@ -22,17 +46,63 @@ type alias Model =
 initialModel : Model
 initialModel =
     { audioSettings = AudioSettings.defaultAudioSettings
+    , currentPitch = Nothing
+    , layoutSelection = Auto
+    , menuOpen = False
+    , modal = NoModal
+    , proposedMovement = None
     , scale = Diatonic
     , showSpacing = False
-    , modal = NoModal
-    , menuOpen = False
-    , currentPitch = Nothing
-    , proposedMovement = None
     , viewport =
         { scene = { width = 0, height = 0 }
         , viewport = { x = 0, y = 0, width = 0, height = 0 }
         }
     }
+
+
+
+-- LAYOUT
+
+
+type LayoutSelection
+    = Auto
+    | Manual Layout
+
+
+type Layout
+    = Portrait
+    | Landscape
+
+
+{-| The specifics here will need work. Portrait should be the default, and Auto
+should only kick into landscape if the height is sufficiently small, or perhaps
+if the ratio is beneath some threshold.
+-}
+layout : Dom.Viewport -> LayoutSelection -> Layout
+layout viewport layoutSelection =
+    case layoutSelection of
+        Auto ->
+            if viewport.scene.width > viewport.scene.height then
+                Landscape
+
+            else
+                Portrait
+
+        Manual layout_ ->
+            layout_
+
+
+layoutString : LayoutSelection -> String
+layoutString layoutSelection =
+    case layoutSelection of
+        Auto ->
+            "Auto"
+
+        Manual Portrait ->
+            "Portrait"
+
+        Manual Landscape ->
+            "Landscape"
 
 
 

--- a/src/Model.elm
+++ b/src/Model.elm
@@ -25,7 +25,7 @@ module Model exposing
 
 import AudioSettings exposing (AudioSettings)
 import Browser.Dom as Dom
-import Byzantine.Degree exposing (Degree)
+import Byzantine.Degree exposing (Degree(..))
 import Byzantine.Scale exposing (Scale(..))
 import Movement exposing (Movement(..))
 
@@ -37,6 +37,8 @@ type alias Model =
     , menuOpen : Bool
     , modal : Modal
     , proposedMovement : Movement
+    , rangeStart : Degree
+    , rangeEnd : Degree
     , scale : Scale
     , showSpacing : Bool
     }
@@ -53,6 +55,8 @@ initialModel =
         }
     , menuOpen = False
     , modal = NoModal
+    , rangeStart = Ni
+    , rangeEnd = Ni_
     , proposedMovement = None
     , scale = Diatonic
     , showSpacing = False

--- a/src/Model.elm
+++ b/src/Model.elm
@@ -1,6 +1,6 @@
 module Model exposing
     ( Model, initialModel
-    , LayoutSelection(..), Layout(..), layout, layoutString
+    , LayoutSelection(..), Layout(..), layoutFor, layoutString
     , Modal(..), modalOpen, modalToString
     )
 
@@ -14,7 +14,7 @@ module Model exposing
 
 # Layout
 
-@docs LayoutSelection, Layout, layout, layoutString
+@docs LayoutSelection, Layout, layoutFor, layoutString
 
 
 # Modal
@@ -78,15 +78,12 @@ type Layout
 should only kick into landscape if the height is sufficiently small, or perhaps
 if the ratio is beneath some threshold.
 -}
-layout : Dom.Viewport -> LayoutSelection -> Layout
-layout viewport layoutSelection =
+layoutFor : Model -> Layout
+layoutFor { layoutSelection, viewport } =
     case layoutSelection of
         Auto ->
-            if viewport.scene.width > viewport.scene.height then
-                Landscape
-
-            else
-                Portrait
+            -- TODO: implement.
+            Portrait
 
         Manual layout_ ->
             layout_

--- a/src/Model.elm
+++ b/src/Model.elm
@@ -50,8 +50,8 @@ initialModel =
     , currentPitch = Nothing
     , layout =
         { layoutSelection = Auto
-        , viewport = emptyViewport
-        , viewportOfPitchSpace = emptyViewport
+        , pitchSpace = defaultElement
+        , viewport = defaultViewport
         }
     , menuOpen = False
     , modal = NoModal
@@ -63,10 +63,24 @@ initialModel =
     }
 
 
-emptyViewport : Dom.Viewport
-emptyViewport =
+{-| Initial hardcoded height 256 prevents negative width settings which
+enables a smooth css transition.
+-}
+defaultViewport : Dom.Viewport
+defaultViewport =
+    { scene = { width = 0, height = 0 }
+    , viewport = { x = 0, y = 0, width = 0, height = 256 }
+    }
+
+
+{-| Initial hardcoded element width of 64 prevents negative width settings which
+enables a smooth css transition.
+-}
+defaultElement : Dom.Element
+defaultElement =
     { scene = { width = 0, height = 0 }
     , viewport = { x = 0, y = 0, width = 0, height = 0 }
+    , element = { x = 0, y = 0, width = 64, height = 0 }
     }
 
 
@@ -76,8 +90,8 @@ emptyViewport =
 
 type alias LayoutData =
     { layoutSelection : LayoutSelection
+    , pitchSpace : Dom.Element
     , viewport : Dom.Viewport
-    , viewportOfPitchSpace : Dom.Viewport
     }
 
 

--- a/src/Movement.elm
+++ b/src/Movement.elm
@@ -1,5 +1,10 @@
 module Movement exposing (Movement(..), ofInterval, toDegree)
 
+{-| A representation of motion within intervallic space. This is more a
+presentational concern rather than a theoretical concept within the system, so,
+for example, there is no purpose in modeling the ison.
+-}
+
 import Byzantine.Degree as Degree exposing (Degree)
 import Byzantine.Pitch exposing (Interval)
 

--- a/src/RadioFieldset.elm
+++ b/src/RadioFieldset.elm
@@ -5,6 +5,7 @@ import Html.Attributes as Attr exposing (checked, class, type_)
 import Html.Events exposing (onClick)
 import Html.Lazy
 import String.Extra exposing (dasherize)
+import Styles
 
 
 type alias Config a msg =
@@ -23,7 +24,7 @@ view config =
         (\config_ ->
             List.map (radioOption config_) config_.options
                 |> (::) (legend [ class "px-1" ] [ text config_.legendText ])
-                |> fieldset [ class "border border-gray-300 rounded-sm px-2 pb-1 mb-2" ]
+                |> fieldset [ Styles.borderRounded, class "px-2 pb-1 mb-2" ]
         )
         config
 
@@ -37,7 +38,7 @@ radioOption config option =
         id =
             "radio-option-" ++ dasherize itemName
     in
-    div [ class "flex flex-row items-center" ]
+    div [ Styles.flexRow, class "items-center" ]
         [ input
             [ type_ "radio"
             , Attr.name ("radio-" ++ dasherize config.legendText)

--- a/src/Styles.elm
+++ b/src/Styles.elm
@@ -1,8 +1,7 @@
 module Styles exposing
-    ( height, width
+    ( bottom, height, width
     , flexRow, flexRowCentered, flexCol
-    , border, buttonClass, transition
-    , borderRounded
+    , border, borderRounded, buttonClass, transition
     )
 
 {-| Style attribute helpers and common Tailwind class combinations
@@ -10,7 +9,7 @@ module Styles exposing
 
 # Styles
 
-@docs height, width
+@docs bottom, height, width
 
 
 # Tailwind Classes
@@ -23,7 +22,7 @@ module Styles exposing
 
 ## Misc
 
-@docs border, buttonClass, transition
+@docs border, borderRounded, buttonClass, transition
 
 -}
 
@@ -33,6 +32,13 @@ import Html.Attributes exposing (class, style)
 
 
 -- STYLE ATTRIBUTES
+
+
+{-| in px: `style="bottom: ${b}px;"`
+-}
+bottom : Int -> Html.Attribute msg
+bottom b =
+    style "bottom" (String.fromInt b ++ "px")
 
 
 {-| in px: `style="height: ${h}px;"`

--- a/src/Styles.elm
+++ b/src/Styles.elm
@@ -1,7 +1,8 @@
 module Styles exposing
     ( height, width
     , flexRow, flexRowCentered, flexCol
-    , buttonClass, transition
+    , border, buttonClass, transition
+    , borderRounded
     )
 
 {-| Style attribute helpers and common Tailwind class combinations
@@ -22,7 +23,7 @@ module Styles exposing
 
 ## Misc
 
-@docs buttonClass, transition
+@docs border, buttonClass, transition
 
 -}
 
@@ -108,6 +109,20 @@ flexCol =
 
 
 -- TAILWIND CLASSES: MISC
+
+
+{-| `class "border border-gray-300"`
+-}
+border : Html.Attribute msg
+border =
+    class "border border-gray-300"
+
+
+{-| `class "border border-gray-300 rounded-md"`
+-}
+borderRounded : Html.Attribute msg
+borderRounded =
+    class "border border-gray-300 rounded-md"
 
 
 {-| `class "bg-gray-200 my-2 py-1 px-3 rounded-md"`

--- a/src/Styles.elm
+++ b/src/Styles.elm
@@ -1,5 +1,6 @@
 module Styles exposing
-    ( bottom, height, width
+    ( height, width
+    , bottom, left
     , flexRow, flexRowCentered, flexCol
     , border, borderRounded, buttonClass, transition
     )
@@ -9,7 +10,15 @@ module Styles exposing
 
 # Styles
 
-@docs bottom, height, width
+
+## Sizing
+
+@docs height, width
+
+
+## Positioning
+
+@docs bottom, left
 
 
 # Tailwind Classes
@@ -31,14 +40,7 @@ import Html.Attributes exposing (class, style)
 
 
 
--- STYLE ATTRIBUTES
-
-
-{-| in px: `style="bottom: ${b}px;"`
--}
-bottom : Int -> Html.Attribute msg
-bottom b =
-    style "bottom" (String.fromInt b ++ "px")
+-- STYLE ATTRIBUTES: SIZING
 
 
 {-| in px: `style="height: ${h}px;"`
@@ -53,6 +55,24 @@ height h =
 width : Int -> Html.Attribute msg
 width w =
     style "width" (String.fromInt w ++ "px")
+
+
+
+-- STYLE ATTRIBUTES: POSITIONING
+
+
+{-| in px: `style="bottom: ${b}px;"`
+-}
+bottom : Int -> Html.Attribute msg
+bottom b =
+    style "bottom" (String.fromInt b ++ "px")
+
+
+{-| in px: `style="left: ${l}px;"`
+-}
+left : Int -> Html.Attribute msg
+left l =
+    style "left" (String.fromInt l ++ "px")
 
 
 

--- a/src/Styles.elm
+++ b/src/Styles.elm
@@ -1,0 +1,124 @@
+module Styles exposing
+    ( height, width
+    , flexRow, flexRowCentered, flexCol
+    , buttonClass, transition
+    )
+
+{-| Style attribute helpers and common Tailwind class combinations
+
+
+# Styles
+
+@docs height, width
+
+
+# Tailwind Classes
+
+
+## Layout
+
+@docs flexRow, flexRowCentered, flexCol
+
+
+## Misc
+
+@docs buttonClass, transition
+
+-}
+
+import Html
+import Html.Attributes exposing (class, style)
+
+
+
+-- STYLE ATTRIBUTES
+
+
+{-| in px: `style="height: ${h}px;"`
+-}
+height : Int -> Html.Attribute msg
+height h =
+    style "height" (String.fromInt h ++ "px")
+
+
+{-| in px: `style="width: ${w}px;"`
+-}
+width : Int -> Html.Attribute msg
+width w =
+    style "width" (String.fromInt w ++ "px")
+
+
+
+-- TAILWIND CLASSES: LAYOUT
+
+
+{-| `class "flex flex-row"`
+
+```css
+.flex {
+    display: flex;
+}
+.flex-row {
+    flex-direction: row;
+}
+```
+
+-}
+flexRow : Html.Attribute msg
+flexRow =
+    class "flex flex-row"
+
+
+{-| `class "flex flex-row justify-center"`
+
+```css
+.flex {
+    display: flex;
+}
+.flex-row {
+    flex-direction: row;
+}
+.justify-center {
+    justify-content: center;
+}
+```
+
+-}
+flexRowCentered : Html.Attribute msg
+flexRowCentered =
+    class "flex flex-row justify-center"
+
+
+{-| `class "flex flex-col"`
+
+```css
+.flex {
+    display: flex;
+}
+.flex-col {
+    flex-direction: column;
+}
+```
+
+-}
+flexCol : Html.Attribute msg
+flexCol =
+    class "flex flex-col"
+
+
+
+-- TAILWIND CLASSES: MISC
+
+
+{-| `class "bg-gray-200 my-2 py-1 px-3 rounded-md"`
+-}
+buttonClass : Html.Attribute msg
+buttonClass =
+    class "bg-gray-200 my-2 py-1 px-3 rounded-md"
+
+
+{-| `class "transition-all duration-500"`
+-}
+transition : Html.Attribute msg
+transition =
+    class "transition-all duration-500"

--- a/src/Styles.elm
+++ b/src/Styles.elm
@@ -7,8 +7,6 @@ module Styles exposing
 
 {-| Style attribute helpers and common Tailwind class combinations
 
-TODO: shoud the positioning and size helpers take floats instead?
-
 
 # Styles
 
@@ -39,6 +37,16 @@ TODO: shoud the positioning and size helpers take floats instead?
 
 import Html
 import Html.Attributes exposing (class, style)
+import Round
+
+
+
+-- HELPERS
+
+
+round2 : Float -> String
+round2 =
+    Round.round 2
 
 
 
@@ -47,16 +55,16 @@ import Html.Attributes exposing (class, style)
 
 {-| in px: `style="height: ${h}px;"`
 -}
-height : Int -> Html.Attribute msg
+height : Float -> Html.Attribute msg
 height h =
-    style "height" (String.fromInt h ++ "px")
+    style "height" (round2 h ++ "px")
 
 
 {-| in px: `style="width: ${w}px;"`
 -}
-width : Int -> Html.Attribute msg
+width : Float -> Html.Attribute msg
 width w =
-    style "width" (String.fromInt w ++ "px")
+    style "width" (round2 w ++ "px")
 
 
 
@@ -65,16 +73,16 @@ width w =
 
 {-| in px: `style="left: ${l}px;"`
 -}
-left : Int -> Html.Attribute msg
+left : Float -> Html.Attribute msg
 left l =
-    style "left" (String.fromInt l ++ "px")
+    style "left" (round2 l ++ "px")
 
 
 {-| in px: `style="top: ${l}px;"`
 -}
-top : Int -> Html.Attribute msg
+top : Float -> Html.Attribute msg
 top l =
-    style "top" (String.fromInt l ++ "px")
+    style "top" (round2 l ++ "px")
 
 
 

--- a/src/Styles.elm
+++ b/src/Styles.elm
@@ -1,11 +1,13 @@
 module Styles exposing
     ( height, width
-    , bottom, left
+    , left, top
     , flexRow, flexRowCentered, flexCol
     , border, borderRounded, buttonClass, transition
     )
 
 {-| Style attribute helpers and common Tailwind class combinations
+
+TODO: shoud the positioning and size helpers take floats instead?
 
 
 # Styles
@@ -18,7 +20,7 @@ module Styles exposing
 
 ## Positioning
 
-@docs bottom, left
+@docs left, top
 
 
 # Tailwind Classes
@@ -61,18 +63,18 @@ width w =
 -- STYLE ATTRIBUTES: POSITIONING
 
 
-{-| in px: `style="bottom: ${b}px;"`
--}
-bottom : Int -> Html.Attribute msg
-bottom b =
-    style "bottom" (String.fromInt b ++ "px")
-
-
 {-| in px: `style="left: ${l}px;"`
 -}
 left : Int -> Html.Attribute msg
 left l =
     style "left" (String.fromInt l ++ "px")
+
+
+{-| in px: `style="top: ${l}px;"`
+-}
+top : Int -> Html.Attribute msg
+top l =
+    style "top" (String.fromInt l ++ "px")
 
 
 

--- a/src/Styles.elm
+++ b/src/Styles.elm
@@ -158,8 +158,8 @@ buttonClass =
     class "bg-gray-200 my-2 py-1 px-3 rounded-md"
 
 
-{-| `class "transition-all duration-500"`
+{-| `class "transition-all duration-800"`
 -}
 transition : Html.Attribute msg
 transition =
-    class "transition-all duration-500"
+    class "transition-all duration-800"

--- a/src/Update.elm
+++ b/src/Update.elm
@@ -5,7 +5,7 @@ import Byzantine.Degree as Degree exposing (Degree(..))
 import Byzantine.Pitch exposing (PitchStandard, Register)
 import Byzantine.Scale exposing (Scale)
 import Maybe.Extra as Maybe
-import Model exposing (Modal, Model)
+import Model exposing (LayoutSelection, Modal, Model)
 import Movement exposing (Movement)
 import Platform.Cmd as Cmd
 import Task
@@ -21,6 +21,7 @@ type Msg
     | SelectPitch (Maybe Degree) (Maybe Movement)
     | SelectProposedMovement Movement
     | SetGain Float
+    | SetLayout LayoutSelection
     | SetPitchStandard PitchStandard
     | SetRegister Register
     | SetScale Scale
@@ -76,6 +77,11 @@ update msg model =
                     model.audioSettings
             in
             ( { model | audioSettings = { audioSettings | gain = clamp 0 1 gain } }
+            , Cmd.none
+            )
+
+        SetLayout layoutSelection ->
+            ( { model | layoutSelection = layoutSelection }
             , Cmd.none
             )
 

--- a/src/Update.elm
+++ b/src/Update.elm
@@ -1,5 +1,6 @@
 module Update exposing (Msg(..), update)
 
+import Array
 import Browser.Dom as Dom
 import Byzantine.Degree as Degree exposing (Degree(..))
 import Byzantine.Pitch exposing (PitchStandard, Register)
@@ -24,6 +25,8 @@ type Msg
     | SetGain Float
     | SetLayout LayoutSelection
     | SetPitchStandard PitchStandard
+    | SetRangeStart String
+    | SetRangeEnd String
     | SetRegister Register
     | SetScale Scale
     | ToggleMenu
@@ -111,6 +114,26 @@ update msg model =
                     model.audioSettings
             in
             ( { model | audioSettings = { audioSettings | pitchStandard = pitchStandard } }
+            , Cmd.none
+            )
+
+        SetRangeStart start ->
+            ( { model
+                | rangeStart =
+                    String.toInt start
+                        |> Maybe.andThen (\i -> Array.get i Degree.gamut)
+                        |> Maybe.withDefault model.rangeStart
+              }
+            , Cmd.none
+            )
+
+        SetRangeEnd end ->
+            ( { model
+                | rangeEnd =
+                    String.toInt end
+                        |> Maybe.andThen (\i -> Array.get i Degree.gamut)
+                        |> Maybe.withDefault model.rangeEnd
+              }
             , Cmd.none
             )
 

--- a/src/Update.elm
+++ b/src/Update.elm
@@ -206,7 +206,10 @@ update msg model =
                         )
 
                     else
-                        ( { model | currentPitch = Nothing }
+                        ( { model
+                            | currentPitch = Nothing
+                            , proposedMovement = Movement.None
+                          }
                         , Cmd.none
                         )
 

--- a/src/View.elm
+++ b/src/View.elm
@@ -48,10 +48,10 @@ view model =
         , main_
             [ class "lg:container lg:mx-auto font-serif"
             , case layoutFor model.layout of
-                Portrait ->
+                Vertical ->
                     class "flex flex-row flex-wrap-reverse"
 
-                Landscape ->
+                Horizontal ->
                     Styles.flexCol
             , Html.Events.on "keydown" keyDecoder
             , Attr.attributeIf model.menuOpen (onClick ToggleMenu)
@@ -198,7 +198,7 @@ settings model =
             { itemToString = layoutString
             , legendText = "Layout"
             , onSelect = SetLayout
-            , options = [ Auto, Manual Portrait, Manual Landscape ]
+            , options = [ Auto, Manual Vertical, Manual Horizontal ]
             , selected = model.layout.layoutSelection
             , viewItem = Nothing
             }

--- a/src/View.elm
+++ b/src/View.elm
@@ -264,7 +264,7 @@ pitchSpace : Model -> Html Msg
 pitchSpace model =
     let
         intervals =
-            Pitch.intervalsFrom model.scale Ni Pa_
+            Pitch.intervalsFrom model.scale model.rangeStart model.rangeEnd
     in
     div
         [ id "pitch-space"

--- a/src/View.elm
+++ b/src/View.elm
@@ -19,7 +19,7 @@ import Icons
 import Json.Decode exposing (Decoder)
 import List.Extra as List
 import Maybe.Extra as Maybe
-import Model exposing (Modal(..), Model)
+import Model exposing (Layout(..), LayoutSelection(..), Modal(..), Model, layoutString)
 import Movement exposing (Movement(..))
 import RadioFieldset
 import Update exposing (Msg(..))
@@ -186,6 +186,14 @@ settings model =
     div [ class "flex flex-col gap-2" ]
         [ spacingButton model.showSpacing
             |> viewIf debuggingLayout
+        , RadioFieldset.view
+            { itemToString = layoutString
+            , legendText = "Layout"
+            , onSelect = SetLayout
+            , options = [ Auto, Manual Portrait, Manual Landscape ]
+            , selected = model.layoutSelection
+            , viewItem = Nothing
+            }
         , RadioFieldset.view
             { itemToString =
                 \register ->

--- a/src/View.elm
+++ b/src/View.elm
@@ -47,7 +47,7 @@ view model =
         , viewIf model.menuOpen menu
         , main_
             [ class "lg:container lg:mx-auto font-serif"
-            , case layoutFor model of
+            , case layoutFor model.layout of
                 Portrait ->
                     class "flex flex-row flex-wrap-reverse"
 
@@ -198,7 +198,7 @@ settings model =
             , legendText = "Layout"
             , onSelect = SetLayout
             , options = [ Auto, Manual Portrait, Manual Landscape ]
-            , selected = model.layoutSelection
+            , selected = model.layout.layoutSelection
             , viewItem = Nothing
             }
         , RadioFieldset.view
@@ -267,9 +267,10 @@ pitchSpace model =
             Pitch.intervalsFrom model.scale Ni Pa_
     in
     div
-        [ class "flex-nowrap"
+        [ id "pitch-space"
+        , class "flex-nowrap"
         , Styles.transition
-        , case layoutFor model of
+        , case layoutFor model.layout of
             Portrait ->
                 class "flex flex-row min-w-[360px]"
 
@@ -297,7 +298,7 @@ intervalCol model intervals =
                 |> List.singleton
     in
     div
-        [ case layoutFor model of
+        [ case layoutFor model.layout of
             Portrait ->
                 class "flex flex-col-reverse w-36"
 
@@ -309,7 +310,7 @@ intervalCol model intervals =
 
 
 viewInterval : Model -> Interval -> Html Msg
-viewInterval ({ currentPitch, proposedMovement, viewport } as model) interval =
+viewInterval ({ currentPitch, proposedMovement } as model) interval =
     let
         viewIntervalCharacter degree =
             currentPitch
@@ -355,11 +356,11 @@ viewInterval ({ currentPitch, proposedMovement, viewport } as model) interval =
                     ( Html.Extra.nothing, [], div )
 
         ( elementLayoutAttrs, spanLayoutAttrs ) =
-            case layoutFor model of
+            case layoutFor model.layout of
                 Portrait ->
                     ( [ Styles.flexRowCentered
                       , class "w-full"
-                      , Styles.height (interval.moria * heightFactor viewport)
+                      , Styles.height (interval.moria * heightFactor model.layout.viewport)
                       ]
                     , [ Styles.flexRow, class "my-auto" ]
                     )
@@ -367,7 +368,7 @@ viewInterval ({ currentPitch, proposedMovement, viewport } as model) interval =
                 Landscape ->
                     ( [ Styles.flexRowCentered
                       , class "h-full"
-                      , Styles.width (interval.moria * widthFactor viewport)
+                      , Styles.width (interval.moria * widthFactor model.layout.viewport)
                       ]
                     , [ class "flex flex-col self-center" ]
                     )
@@ -393,14 +394,14 @@ viewInterval ({ currentPitch, proposedMovement, viewport } as model) interval =
 
 
 spacerInterval : Model -> Interval -> Html Msg
-spacerInterval ({ viewport, showSpacing } as model) { moria } =
+spacerInterval ({ showSpacing } as model) { moria } =
     div
-        [ case layoutFor model of
+        [ case layoutFor model.layout of
             Portrait ->
-                Styles.height (moria * heightFactor viewport // 2)
+                Styles.height (moria * heightFactor model.layout.viewport // 2)
 
             Landscape ->
-                Styles.width (moria * widthFactor viewport // 2)
+                Styles.width (moria * widthFactor model.layout.viewport // 2)
         , Styles.transition
         , classList
             [ ( "text-center bg-slate-300", showSpacing )
@@ -415,7 +416,7 @@ pitchCol model intervals =
     intervalsToPitchHeights intervals
         |> List.map (viewPitch model)
         |> div
-            [ case layoutFor model of
+            [ case layoutFor model.layout of
                 Portrait ->
                     class "flex flex-col-reverse w-16"
 
@@ -425,7 +426,7 @@ pitchCol model intervals =
 
 
 viewPitch : Model -> PitchHeight -> Html Msg
-viewPitch ({ scale, showSpacing, currentPitch, proposedMovement, viewport } as model) pitchHeight =
+viewPitch ({ scale, showSpacing, currentPitch, proposedMovement } as model) pitchHeight =
     let
         degree =
             Just pitchHeight.degree
@@ -434,12 +435,12 @@ viewPitch ({ scale, showSpacing, currentPitch, proposedMovement, viewport } as m
             degree == currentPitch
 
         layout =
-            layoutFor model
+            layoutFor model.layout
 
         spanAttrs =
             case layout of
                 Portrait ->
-                    [ style "padding-top" <| String.fromInt (pitchHeight.aboveCenter * (heightFactor viewport - 2)) ++ "px"
+                    [ style "padding-top" <| String.fromInt (pitchHeight.aboveCenter * (heightFactor model.layout.viewport - 2)) ++ "px"
                     , Styles.flexRow
                     , class "gap-2 absolute"
                     ]
@@ -447,7 +448,7 @@ viewPitch ({ scale, showSpacing, currentPitch, proposedMovement, viewport } as m
                 Landscape ->
                     [ Styles.flexCol
                     , class "gap-4"
-                    , style "padding-left" <| String.fromInt (pitchHeight.belowCenter * (widthFactor viewport - 6)) ++ "px"
+                    , style "padding-left" <| String.fromInt (pitchHeight.belowCenter * (widthFactor model.layout.viewport - 6)) ++ "px"
                     ]
 
         --     -- for dev purposes only; will eventually be deleted
@@ -462,10 +463,10 @@ viewPitch ({ scale, showSpacing, currentPitch, proposedMovement, viewport } as m
         , Styles.flexRowCentered
         , case layout of
             Portrait ->
-                Styles.height <| (pitchHeight.belowCenter + pitchHeight.aboveCenter) * heightFactor viewport
+                Styles.height <| (pitchHeight.belowCenter + pitchHeight.aboveCenter) * heightFactor model.layout.viewport
 
             Landscape ->
-                Styles.width <| (pitchHeight.belowCenter + pitchHeight.aboveCenter) * widthFactor viewport
+                Styles.width <| (pitchHeight.belowCenter + pitchHeight.aboveCenter) * widthFactor model.layout.viewport
         ]
         [ button
             [ class "flex px-4 w-full rounded-full"
@@ -514,7 +515,7 @@ viewPitch ({ scale, showSpacing, currentPitch, proposedMovement, viewport } as m
 
 viewControls : Model -> Html Msg
 viewControls model =
-    div [ classList [ ( "mt-8", debuggingLayout ) ] ]
+    div [ class "w-max", classList [ ( "mt-8", debuggingLayout ) ] ]
         [ selectScale model
         , viewCurrentPitch model.currentPitch
         , gainInput model.audioSettings

--- a/src/View.elm
+++ b/src/View.elm
@@ -22,6 +22,7 @@ import Maybe.Extra as Maybe
 import Model exposing (Layout(..), LayoutSelection(..), Modal(..), Model, layoutFor, layoutString)
 import Movement exposing (Movement(..))
 import RadioFieldset
+import Styles
 import Update exposing (Msg(..))
 
 
@@ -51,7 +52,7 @@ view model =
                     class "flex flex-row flex-wrap-reverse"
 
                 Landscape ->
-                    class "flex flex-col"
+                    Styles.flexCol
             , Html.Events.on "keydown" keyDecoder
             , Attr.attributeIf model.menuOpen (onClick ToggleMenu)
             ]
@@ -69,7 +70,7 @@ backdrop model =
     in
     div
         [ class "fixed top-0 left-0 w-full h-full"
-        , transition
+        , Styles.transition
         , classList
             [ ( "-z-10", not show )
             , ( "bg-slate-400 opacity-40 z-10", show )
@@ -100,9 +101,7 @@ audio model =
 
 header : Model -> Html Msg
 header model =
-    Html.header
-        [ class "flex flex-row justify-center"
-        ]
+    Html.header [ Styles.flexRowCentered ]
         [ div [ class "w-7" ] []
         , div [ class "flex-1 flex flex-col mb-4 mx-4" ]
             [ h1 [ class "font-heading text-4xl text-center" ]
@@ -128,7 +127,7 @@ menu =
             Html.li []
                 [ button
                     [ class "p-2 hover:bg-gray-200 w-full"
-                    , transition
+                    , Styles.transition
                     , onClick (SelectModal modal)
                     ]
                     [ text (Model.modalToString modal) ]
@@ -266,7 +265,8 @@ pitchSpace model =
             Pitch.intervalsFrom model.scale Ni Pa_
     in
     div
-        [ class "flex-nowrap transition-all duration-500"
+        [ class "flex-nowrap"
+        , Styles.transition
         , case layoutFor model of
             Portrait ->
                 class "flex flex-row min-w-[360px]"
@@ -355,22 +355,24 @@ viewInterval ({ currentPitch, proposedMovement, viewport } as model) interval =
         ( elementLayoutAttrs, spanLayoutAttrs ) =
             case layoutFor model of
                 Portrait ->
-                    ( [ class "flex flex-row justify-center w-full"
-                      , height (interval.moria * heightFactor viewport)
+                    ( [ Styles.flexRowCentered
+                      , class "w-full"
+                      , Styles.height (interval.moria * heightFactor viewport)
                       ]
-                    , [ class "flex flex-row my-auto" ]
+                    , [ Styles.flexRow, class "my-auto" ]
                     )
 
                 Landscape ->
-                    ( [ class "flex flex-row justify-center h-full"
-                      , width (interval.moria * widthFactor viewport)
+                    ( [ Styles.flexRowCentered
+                      , class "h-full"
+                      , Styles.width (interval.moria * widthFactor viewport)
                       ]
                     , [ class "flex flex-col self-center" ]
                     )
     in
     element
         ([ class "border border-gray-300"
-         , transition
+         , Styles.transition
          , classList
             [ ( "bg-slate-200"
               , shouldHighlight currentPitch proposedMovement interval
@@ -393,11 +395,11 @@ spacerInterval ({ viewport, showSpacing } as model) { moria } =
     div
         [ case layoutFor model of
             Portrait ->
-                height (moria * heightFactor viewport // 2)
+                Styles.height (moria * heightFactor viewport // 2)
 
             Landscape ->
-                width (moria * widthFactor viewport // 2)
-        , transition
+                Styles.width (moria * widthFactor viewport // 2)
+        , Styles.transition
         , classList
             [ ( "text-center bg-slate-300", showSpacing )
             , ( "pt-9", True )
@@ -452,19 +454,19 @@ viewPitch ({ scale, showSpacing, currentPitch, proposedMovement, viewport } as m
     in
     div
         [ classList [ ( "border border-gray-500 bg-slate-200", showSpacing ) ]
-        , transition
-        , class "flex flex-row justify-center"
+        , Styles.transition
+        , Styles.flexRowCentered
         , case layout of
             Portrait ->
-                height <| (pitchHeight.belowCenter + pitchHeight.aboveCenter) * heightFactor viewport
+                Styles.height <| (pitchHeight.belowCenter + pitchHeight.aboveCenter) * heightFactor viewport
 
             Landscape ->
-                width <| (pitchHeight.belowCenter + pitchHeight.aboveCenter) * widthFactor viewport
+                Styles.width <| (pitchHeight.belowCenter + pitchHeight.aboveCenter) * widthFactor viewport
         ]
         [ button
             [ class "flex px-4 w-full rounded-full"
             , id <| "p_" ++ Degree.toString pitchHeight.degree
-            , transition
+            , Styles.transition
             , classList
                 [ ( "bg-green-300", showSpacing ) -- for dev purposes only; will eventually be deleted
                 , ( "text-green-700 bg-slate-200", Movement.toDegree proposedMovement == degree )
@@ -478,7 +480,11 @@ viewPitch ({ scale, showSpacing, currentPitch, proposedMovement, viewport } as m
                 else
                     SelectPitch degree Nothing
             ]
-            [ span (transition :: classList [ ( "text-red-600", isCurrentPitch ) ] :: spanAttrs)
+            [ span
+                (Styles.transition
+                    :: classList [ ( "text-red-600", isCurrentPitch ) ]
+                    :: spanAttrs
+                )
                 [ div
                     [ class "text-xl sm:text-3xl relative"
                     , case layout of
@@ -514,7 +520,7 @@ viewControls model =
 spacingButton : Bool -> Html Msg
 spacingButton showSpacing =
     button
-        [ buttonClass
+        [ Styles.buttonClass
         , onClick ToggleSpacing
         ]
         [ text <|
@@ -555,7 +561,7 @@ viewCurrentPitch pitch =
 clearPitchButton : Html Msg
 clearPitchButton =
     button
-        [ buttonClass
+        [ Styles.buttonClass
         , class "mx-2"
         , onClick (SelectPitch Nothing Nothing)
         ]
@@ -574,7 +580,7 @@ gainInput { gain } =
     in
     div []
         [ button
-            [ buttonClass
+            [ Styles.buttonClass
             , class "w-24 mr-4"
             , onClick msg
             ]
@@ -595,18 +601,6 @@ gainInput { gain } =
 -- HELPERS
 
 
-buttonClass : Html.Attribute Msg
-buttonClass =
-    class "bg-gray-200 my-2 py-1 px-3 rounded-md"
-
-
-{-| in px: `style=height: ${h}px;`
--}
-height : Int -> Html.Attribute Msg
-height h =
-    style "height" (String.fromInt h ++ "px")
-
-
 heightFactor : Dom.Viewport -> Int
 heightFactor viewport =
     (viewport.viewport.height / 100)
@@ -614,23 +608,11 @@ heightFactor viewport =
         |> clamp 6 12
 
 
-{-| in px: `style=width: ${w}px;`
--}
-width : Int -> Html.Attribute Msg
-width w =
-    style "width" (String.fromInt w ++ "px")
-
-
 widthFactor : Dom.Viewport -> Int
 widthFactor viewport =
     (viewport.viewport.width / 100)
         |> truncate
         |> clamp 6 18
-
-
-transition : Html.Attribute Msg
-transition =
-    class "transition-all duration-500"
 
 
 shouldHighlight : Maybe Degree -> Movement -> Interval -> Bool

--- a/src/View.elm
+++ b/src/View.elm
@@ -103,7 +103,7 @@ header : Model -> Html Msg
 header model =
     Html.header [ Styles.flexRowCentered ]
         [ div [ class "w-7" ] []
-        , div [ class "flex-1 flex flex-col mb-4 mx-4" ]
+        , div [ Styles.flexCol, class "flex-1 mb-4 mx-4" ]
             [ h1 [ class "font-heading text-4xl text-center" ]
                 [ text "ByzanTone" ]
             , p [ class "font-serif text-center" ]
@@ -134,7 +134,8 @@ menu =
                 ]
     in
     Html.ul
-        [ class "fixed top-0 right-0 z-50 bg-white border border-gray-300 rounded-md shadow-md"
+        [ class "fixed top-0 right-0 z-50 bg-white shadow-md"
+        , Styles.borderRounded
         , class "font-serif"
         , id "menu"
         , Html.Events.on "keydown" keyDecoder
@@ -155,12 +156,13 @@ viewModal model =
         _ ->
             Html.node "dialog"
                 [ class "fixed inset-1/4 top-24 w-3/4 md:w-1/2 z-10"
-                , class "flex flex-col"
+                , Styles.flexCol
                 , class "p-6 bg-white"
-                , class "border border-gray-300 rounded-md shadow-md font-serif"
+                , Styles.borderRounded
+                , class "shadow-md font-serif"
                 , id "modal"
                 ]
-                [ h2 [ class "flex flex-row justify-between mb-1" ]
+                [ h2 [ Styles.flexRow, class "justify-between mb-1" ]
                     [ span [ class "font-heading text-2xl" ]
                         [ text (Model.modalToString model.modal) ]
                     , button
@@ -188,7 +190,7 @@ modalContent model =
 
 settings : Model -> Html Msg
 settings model =
-    div [ class "flex flex-col gap-2" ]
+    div [ Styles.flexCol, class "gap-2" ]
         [ spacingButton model.showSpacing
             |> viewIf debuggingLayout
         , RadioFieldset.view
@@ -272,7 +274,7 @@ pitchSpace model =
                 class "flex flex-row min-w-[360px]"
 
             Landscape ->
-                class "flex flex-col"
+                Styles.flexCol
         ]
         [ intervalCol model intervals
         , pitchCol model intervals
@@ -371,7 +373,7 @@ viewInterval ({ currentPitch, proposedMovement, viewport } as model) interval =
                     )
     in
     element
-        ([ class "border border-gray-300"
+        ([ Styles.border
          , Styles.transition
          , classList
             [ ( "bg-slate-200"
@@ -438,11 +440,13 @@ viewPitch ({ scale, showSpacing, currentPitch, proposedMovement, viewport } as m
             case layout of
                 Portrait ->
                     [ style "padding-top" <| String.fromInt (pitchHeight.aboveCenter * (heightFactor viewport - 2)) ++ "px"
-                    , class "flex flex-row gap-2 absolute"
+                    , Styles.flexRow
+                    , class "gap-2 absolute"
                     ]
 
                 Landscape ->
-                    [ class "flex flex-col gap-4"
+                    [ Styles.flexCol
+                    , class "gap-4"
                     , style "padding-left" <| String.fromInt (pitchHeight.belowCenter * (widthFactor viewport - 6)) ++ "px"
                     ]
 

--- a/src/View/PitchSpace.elm
+++ b/src/View/PitchSpace.elm
@@ -1,0 +1,628 @@
+module View.PitchSpace exposing (view)
+
+{-| View logic for pitch space (i.e., the intervalic space and positioned pitches)
+-}
+
+import Byzantine.ByzHtml.Interval as ByzHtmlInterval
+import Byzantine.ByzHtml.Martyria as ByzHtmlMartyria
+import Byzantine.Degree as Degree exposing (Degree)
+import Byzantine.IntervalCharacter as IntervalCharacter
+import Byzantine.Martyria as Martyria
+import Byzantine.Pitch as Pitch exposing (Interval)
+import Html exposing (Html, button, div, li, span, text)
+import Html.Attributes as Attr exposing (class, classList)
+import Html.Attributes.Extra as Attr
+import Html.Events exposing (onClick, onFocus, onMouseEnter)
+import Html.Extra exposing (viewIf, viewIfLazy)
+import Html.Keyed
+import Maybe.Extra as Maybe
+import Model exposing (Layout(..), LayoutData, Model, layoutFor)
+import Movement exposing (Movement(..))
+import Styles
+import Update exposing (Msg(..))
+
+
+
+-- HELPER TYPES AND FUNCTIONS
+
+
+{-| What is the visible range of the pitch space? This expands the default (or
+user-set) start and stop positions to include the current pitch. (We may want to
+consider additional limits as well.)
+-}
+visibleRange : Model -> { start : Degree, end : Degree }
+visibleRange model =
+    case model.currentPitch of
+        Just currentPitch ->
+            { start =
+                if Degree.indexOf currentPitch < Degree.indexOf model.rangeStart then
+                    currentPitch
+
+                else
+                    model.rangeStart
+            , end =
+                if Degree.indexOf currentPitch > Degree.indexOf model.rangeEnd then
+                    currentPitch
+
+                else
+                    model.rangeEnd
+            }
+
+        Nothing ->
+            { start = model.rangeStart
+            , end = model.rangeEnd
+            }
+
+
+visibleRangeInMoria : Model -> Int
+visibleRangeInMoria model =
+    let
+        { start, end } =
+            visibleRange model
+    in
+    Pitch.pitchPosition model.scale end - Pitch.pitchPosition model.scale start
+
+
+type PositionWithinVisibleRange
+    = Below
+    | LowerBoundary
+    | Within
+    | UpperBoundary
+    | Above
+
+
+{-| not actually needed; just for fun
+-}
+positionString : PositionWithinVisibleRange -> String
+positionString position =
+    case position of
+        Below ->
+            "Below"
+
+        LowerBoundary ->
+            "LowerBoundary"
+
+        Within ->
+            "Within"
+
+        UpperBoundary ->
+            "UpperBoundary"
+
+        Above ->
+            "Above"
+
+
+positionIsVisible : PositionWithinVisibleRange -> Bool
+positionIsVisible position =
+    case position of
+        Below ->
+            False
+
+        LowerBoundary ->
+            True
+
+        Within ->
+            True
+
+        UpperBoundary ->
+            True
+
+        Above ->
+            False
+
+
+{-| TODO: refactor to process as a list so it's not re-computing the visible
+range over and over.
+-}
+pitchPositionWithinVisibleRange : Model -> Degree -> PositionWithinVisibleRange
+pitchPositionWithinVisibleRange model degree =
+    let
+        pitchIndex =
+            Degree.indexOf degree
+
+        { start, end } =
+            visibleRange model
+
+        lowerBoundIndex =
+            Degree.indexOf start
+
+        upperBoundIndex =
+            Degree.indexOf end
+    in
+    if pitchIndex < lowerBoundIndex then
+        Below
+
+    else if pitchIndex == lowerBoundIndex then
+        LowerBoundary
+
+    else if pitchIndex > upperBoundIndex then
+        Above
+
+    else if pitchIndex == upperBoundIndex then
+        UpperBoundary
+
+    else
+        Within
+
+
+intervalPositionWithinVisibleRange : Model -> Interval -> PositionWithinVisibleRange
+intervalPositionWithinVisibleRange model interval =
+    let
+        { start, end } =
+            visibleRange model
+
+        lowerBoundIndex =
+            Degree.indexOf start
+
+        upperBoundIndex =
+            Degree.indexOf end
+
+        intervalFromIndex =
+            Degree.indexOf interval.from
+
+        intervalToIndex =
+            Degree.indexOf interval.to
+    in
+    if lowerBoundIndex == intervalFromIndex then
+        LowerBoundary
+
+    else if upperBoundIndex == intervalToIndex then
+        UpperBoundary
+
+    else if intervalToIndex <= lowerBoundIndex then
+        Below
+
+    else if intervalFromIndex >= upperBoundIndex then
+        Above
+
+    else
+        Within
+
+
+{-| This feels potentially fragile.
+
+TODO: we'll need some sort of minimum for the portrait to enable scrolling on
+small viewports.
+
+-}
+scalingFactor : LayoutData -> Int -> Float
+scalingFactor layoutData rangeInMoria =
+    let
+        marginForButton =
+            pitchButtonSize layoutData |> toFloat
+    in
+    case layoutFor layoutData of
+        Portrait ->
+            (layoutData.viewport.viewport.height
+                - max layoutData.pitchSpace.element.y 128
+                - marginForButton
+            )
+                / toFloat rangeInMoria
+
+        Landscape ->
+            (layoutData.pitchSpace.element.width
+                - marginForButton
+            )
+                / toFloat rangeInMoria
+
+
+
+-- WRAPPER
+
+
+{-| may want padding on this.
+-}
+view : Model -> Html Msg
+view model =
+    div
+        ([ Attr.id "pitch-space"
+         , Styles.transition
+         , Attr.attributeIf model.showSpacing Styles.border
+         ]
+            ++ (case layoutFor model.layout of
+                    Portrait ->
+                        [ Styles.flexRow
+                        , class "my-8"
+                        ]
+
+                    Landscape ->
+                        [ Styles.flexCol
+                        , class "mx-8"
+                        ]
+               )
+        )
+        -- , class "flex-nowrap"
+        [ viewIntervals model
+        , viewPitches model
+        ]
+
+
+
+-- LAYOUT HELPERS
+
+
+{-| Hypothesis is that this will work for both pitch column and
+the interval column. We'll have to see, though.
+-}
+listAttributes : LayoutData -> List (Html.Attribute Msg)
+listAttributes layoutData =
+    case layoutFor layoutData of
+        Portrait ->
+            [ class "flex flex-col-reverse justify-end w-36 mx-4"
+
+            -- , Styles.height (truncate layoutData.viewport.viewport.height - 200)
+            ]
+
+        Landscape ->
+            [ Styles.flexRowCentered
+            , class "h-24 w-full my-4"
+            ]
+
+
+
+-- INTERVAL COLUMN
+
+
+viewIntervals : Model -> Html Msg
+viewIntervals model =
+    Html.Keyed.ol (listAttributes model.layout)
+        (List.map (viewInterval model (visibleRangeInMoria model))
+            (Pitch.intervals model.scale)
+        )
+
+
+viewInterval : Model -> Int -> Interval -> ( String, Html Msg )
+viewInterval model rangeInMoria interval =
+    let
+        id =
+            "interval-" ++ Degree.toString interval.from ++ "-" ++ Degree.toString interval.to
+
+        position =
+            intervalPositionWithinVisibleRange model interval
+
+        layout =
+            layoutFor model.layout
+
+        size =
+            case position of
+                Above ->
+                    0
+
+                Below ->
+                    0
+
+                _ ->
+                    scalingFactor model.layout rangeInMoria
+                        -- (case layout of
+                        --     Portrait ->
+                        --         model.layout.viewport.viewport.height
+                        --     Landscape ->
+                        --         -- TODO: may want to consider truncating this somehow
+                        --         model.layout.viewportOfPitchSpace.viewport.width
+                        -- )
+                        --     / toFloat rangeInMoria
+                        * toFloat interval.moria
+                        |> round
+
+        movement =
+            Movement.ofInterval model.currentPitch interval
+
+        moria =
+            span [ class "text-gray-600" ]
+                [ text (String.fromInt interval.moria)
+                , viewIf model.showSpacing
+                    (text <| " (" ++ String.fromInt size ++ "px)")
+                ]
+
+        buttonAttrs =
+            [ class "w-full content-center cursor-pointer"
+            , classList
+                [ ( "bg-slate-200"
+                  , shouldHighlightInterval model.currentPitch model.proposedMovement interval
+                  )
+                , ( "hover:bg-slate-200", Maybe.isJust model.currentPitch )
+                ]
+            , onFocus (SelectProposedMovement movement)
+            , onMouseEnter (SelectProposedMovement movement)
+            ]
+    in
+    ( id
+    , li
+        [ Attr.id id
+        , class <| positionString position
+        , Styles.flexRowCentered
+        , case layout of
+            Portrait ->
+                Styles.height size
+
+            Landscape ->
+                Styles.width size
+        , Styles.transition
+        , Attr.attributeIf (positionIsVisible position) Styles.border
+        ]
+        [ (case movement of
+            AscendTo degree ->
+                button
+                    (onClick (SelectPitch (Just degree) (Maybe.map DescendTo (Degree.step degree -1)))
+                        :: buttonAttrs
+                    )
+                    [ viewIntervalCharacter model.currentPitch degree
+                    , moria
+                    ]
+
+            DescendTo degree ->
+                button
+                    (onClick (SelectPitch (Just degree) (Maybe.map AscendTo (Degree.step degree 1)))
+                        :: buttonAttrs
+                    )
+                    [ viewIntervalCharacter model.currentPitch degree
+                    , moria
+                    ]
+
+            None ->
+                div [ class "content-center" ]
+                    [ moria ]
+          )
+            |> viewIf (positionIsVisible position)
+        ]
+    )
+
+
+viewIntervalCharacter : Maybe Degree -> Degree -> Html Msg
+viewIntervalCharacter currentPitch degree =
+    currentPitch
+        |> Maybe.map (\current -> Degree.getInterval current degree)
+        |> Maybe.andThen IntervalCharacter.basicInterval
+        |> Html.Extra.viewMaybe
+            (ByzHtmlInterval.view >> List.singleton >> span [ class "me-2" ])
+
+
+shouldHighlightInterval : Maybe Degree -> Movement -> Interval -> Bool
+shouldHighlightInterval currentPitch proposedMovement interval =
+    Maybe.unwrap False
+        (\current ->
+            let
+                currentPitchIndex =
+                    Degree.indexOf current
+
+                fromIndex =
+                    Degree.indexOf interval.from
+
+                toIndex =
+                    Degree.indexOf interval.to
+            in
+            case proposedMovement of
+                AscendTo degree ->
+                    (currentPitchIndex < toIndex)
+                        && (toIndex <= Degree.indexOf degree)
+
+                DescendTo degree ->
+                    (currentPitchIndex > fromIndex)
+                        && (fromIndex >= Degree.indexOf degree)
+
+                None ->
+                    False
+        )
+        currentPitch
+
+
+
+-- PITCH COLUMN
+
+
+viewPitches : Model -> Html Msg
+viewPitches model =
+    Html.Keyed.ol (listAttributes model.layout)
+        (List.map (viewPitch model (visibleRangeInMoria model)) Degree.gamutList)
+
+
+viewPitch : Model -> Int -> Degree -> ( String, Html Msg )
+viewPitch model rangeInMoria degree =
+    let
+        id =
+            "pitch-" ++ Degree.toString degree
+
+        layout =
+            layoutFor model.layout
+
+        positionWithinRange =
+            pitchPositionWithinVisibleRange model degree
+
+        pitch =
+            Pitch.pitchPosition model.scale degree
+
+        pitchBelow =
+            Degree.step degree -1
+                |> Maybe.map (Pitch.pitchPosition model.scale)
+
+        pitchAbove =
+            Degree.step degree 1
+                |> Maybe.map (Pitch.pitchPosition model.scale)
+
+        scalingFactor_ =
+            scalingFactor model.layout rangeInMoria
+
+        size =
+            case positionWithinRange of
+                Below ->
+                    0
+
+                LowerBoundary ->
+                    Maybe.map
+                        (\above -> toFloat (above - pitch) / 2)
+                        pitchAbove
+                        |> Maybe.withDefault 0
+                        |> (*) scalingFactor_
+                        |> round
+
+                Within ->
+                    Maybe.map2
+                        (\below above -> (toFloat (above - pitch) / 2) + (toFloat (pitch - below) / 2))
+                        pitchBelow
+                        pitchAbove
+                        |> Maybe.withDefault 0
+                        |> (*) scalingFactor_
+                        |> round
+
+                UpperBoundary ->
+                    Maybe.map
+                        (\below -> toFloat (pitch - below) / 2)
+                        pitchBelow
+                        |> Maybe.withDefault 0
+                        |> (*) scalingFactor_
+                        |> round
+
+                Above ->
+                    0
+
+        showSpacingDetails =
+            model.showSpacing && positionIsVisible positionWithinRange
+
+        attributeIfVisible =
+            Attr.attributeIf (positionIsVisible positionWithinRange)
+    in
+    ( id
+    , li
+        [ Attr.id id
+        , class <| positionString positionWithinRange
+        , Styles.transition
+        , Attr.attributeIf showSpacingDetails Styles.border
+        , attributeIfVisible Styles.flexCol
+        , case layout of
+            Portrait ->
+                Styles.height size
+
+            Landscape ->
+                Styles.width size
+        ]
+        [ viewIfLazy (positionIsVisible positionWithinRange)
+            (\_ ->
+                pitchButton model
+                    { degree = degree
+                    , pitch = pitch
+                    , pitchAbove = pitchAbove
+                    , pitchBelow = pitchBelow
+                    , positionWithinRange = positionWithinRange
+                    , scalingFactor_ = scalingFactor_
+                    }
+            )
+        , viewIf showSpacingDetails
+            (text (" (" ++ String.fromInt size ++ "px)"))
+        ]
+    )
+
+
+pitchButton :
+    Model
+    ->
+        { degree : Degree
+        , pitch : Int
+        , pitchAbove : Maybe Int
+        , pitchBelow : Maybe Int
+        , positionWithinRange : PositionWithinVisibleRange
+        , scalingFactor_ : Float
+        }
+    -> Html Msg
+pitchButton model { degree, pitch, pitchAbove, pitchBelow, positionWithinRange, scalingFactor_ } =
+    let
+        isCurrentPitch =
+            Just degree == model.currentPitch
+
+        layout =
+            layoutFor model.layout
+
+        position =
+            case ( layout, positionWithinRange ) of
+                ( _, Below ) ->
+                    0
+
+                ( Portrait, LowerBoundary ) ->
+                    Maybe.map
+                        (\above -> toFloat (above - pitch) / 2)
+                        pitchAbove
+                        |> Maybe.withDefault 0
+                        |> (*) scalingFactor_
+                        |> round
+                        |> (+) (negate pitchButtonSizeValue)
+
+                ( Landscape, LowerBoundary ) ->
+                    negate pitchButtonSizeValue
+
+                ( Portrait, Within ) ->
+                    Maybe.map
+                        (\above -> toFloat (above - pitch) / 2)
+                        pitchAbove
+                        |> Maybe.withDefault 0
+                        |> (*) scalingFactor_
+                        |> round
+                        |> (+) (negate pitchButtonSizeValue)
+
+                ( Landscape, Within ) ->
+                    Maybe.map
+                        (\below -> toFloat (pitch - below) / 2)
+                        pitchBelow
+                        |> Maybe.withDefault 0
+                        |> (*) scalingFactor_
+                        |> round
+                        |> (+) (negate pitchButtonSizeValue)
+
+                ( Portrait, UpperBoundary ) ->
+                    negate pitchButtonSizeValue
+
+                ( Landscape, UpperBoundary ) ->
+                    Maybe.map
+                        (\below -> toFloat (pitch - below) / 2)
+                        pitchBelow
+                        |> Maybe.withDefault 0
+                        |> (*) scalingFactor_
+                        |> round
+                        |> (+) (negate pitchButtonSizeValue)
+
+                ( _, Above ) ->
+                    0
+
+        pitchButtonSizeValue =
+            pitchButtonSize model.layout // 2
+    in
+    button
+        [ onClick <|
+            if isCurrentPitch then
+                SelectPitch Nothing Nothing
+
+            else
+                SelectPitch (Just degree) Nothing
+        , pitchButtonSizeClass
+        , class "rounded-full hover:z-10 cursor-pointer relative pb-8"
+        , Styles.transition
+        , case layoutFor model.layout of
+            Portrait ->
+                Styles.top position
+
+            Landscape ->
+                Styles.left position
+        , classList
+            [ ( "bg-red-200", isCurrentPitch )
+            , ( "hover:text-green-700 bg-slate-200 hover:bg-slate-300 opacity-75 hover:opacity-100", not isCurrentPitch )
+            , ( "text-green-700 bg-slate-300 z-10", Movement.toDegree model.proposedMovement == Just degree )
+            ]
+        ]
+        [ ByzHtmlMartyria.viewWithAttributes
+            [ Styles.left -3, Styles.top -3 ]
+            (Martyria.for model.scale degree)
+        ]
+
+
+{-| 64px default, 48px below the sm breakpoint.
+-}
+pitchButtonSizeClass : Html.Attribute msg
+pitchButtonSizeClass =
+    class "w-12 h-12 sm:w-16 sm:h-16 text-xl sm:text-3xl"
+
+
+pitchButtonSize : LayoutData -> Int
+pitchButtonSize layoutData =
+    if layoutData.viewport.viewport.width < 640 then
+        48
+
+    else
+        64

--- a/src/View/PitchSpace.elm
+++ b/src/View/PitchSpace.elm
@@ -12,7 +12,7 @@ import Byzantine.Pitch as Pitch exposing (Interval)
 import Html exposing (Html, button, div, li, span, text)
 import Html.Attributes as Attr exposing (class, classList)
 import Html.Attributes.Extra as Attr
-import Html.Events exposing (onClick, onFocus, onMouseEnter)
+import Html.Events exposing (onClick, onFocus, onMouseEnter, onMouseLeave)
 import Html.Extra exposing (viewIf, viewIfLazy)
 import Maybe.Extra as Maybe
 import Model exposing (Layout(..), LayoutData, Model, layoutFor)
@@ -254,7 +254,7 @@ listAttributes layoutData =
 
 viewIntervals : Model -> Html Msg
 viewIntervals model =
-    Html.ol (listAttributes model.layout)
+    Html.ol (onMouseLeave (SelectProposedMovement None) :: listAttributes model.layout)
         (List.map
             (viewInterval model (visibleRangeInMoria model))
             (intervalsWithVisibility model)

--- a/src/View/PitchSpace.elm
+++ b/src/View/PitchSpace.elm
@@ -17,6 +17,7 @@ import Html.Extra exposing (viewIf, viewIfLazy)
 import Maybe.Extra as Maybe
 import Model exposing (Layout(..), LayoutData, Model, layoutFor)
 import Movement exposing (Movement(..))
+import Round
 import Styles
 import Update exposing (Msg(..))
 
@@ -180,7 +181,7 @@ scalingFactor : LayoutData -> Int -> Float
 scalingFactor layoutData rangeInMoria =
     let
         marginForButton =
-            pitchButtonSize layoutData |> toFloat
+            pitchButtonSize layoutData
     in
     case layoutFor layoutData of
         Vertical ->
@@ -277,7 +278,6 @@ viewInterval model rangeInMoria ( interval, position ) =
                 _ ->
                     scalingFactor model.layout rangeInMoria
                         * toFloat interval.moria
-                        |> round
 
         movement =
             Movement.ofInterval model.currentPitch interval
@@ -286,7 +286,7 @@ viewInterval model rangeInMoria ( interval, position ) =
             span [ class "text-gray-600" ]
                 [ text (String.fromInt interval.moria)
                 , viewIf model.showSpacing
-                    (text <| " (" ++ String.fromInt size ++ "px)")
+                    (text <| " (" ++ Round.round 2 size ++ "px)")
                 ]
 
         buttonAttrs =
@@ -419,7 +419,6 @@ viewPitch model rangeInMoria ( degree, positionWithinRange ) =
                         pitchAbove
                         |> Maybe.withDefault 0
                         |> (*) scalingFactor_
-                        |> round
 
                 Within ->
                     Maybe.map2
@@ -428,7 +427,6 @@ viewPitch model rangeInMoria ( degree, positionWithinRange ) =
                         pitchAbove
                         |> Maybe.withDefault 0
                         |> (*) scalingFactor_
-                        |> round
 
                 UpperBoundary ->
                     Maybe.map
@@ -436,7 +434,6 @@ viewPitch model rangeInMoria ( degree, positionWithinRange ) =
                         pitchBelow
                         |> Maybe.withDefault 0
                         |> (*) scalingFactor_
-                        |> round
 
                 Above ->
                     0
@@ -471,7 +468,7 @@ viewPitch model rangeInMoria ( degree, positionWithinRange ) =
                     }
             )
         , viewIf showSpacingDetails
-            (text (" (" ++ String.fromInt size ++ "px)"))
+            (text (" (" ++ Round.round 2 size ++ "px)"))
         ]
 
 
@@ -505,7 +502,6 @@ pitchButton model { degree, pitch, pitchAbove, pitchBelow, positionWithinRange, 
                         pitchAbove
                         |> Maybe.withDefault 0
                         |> (*) scalingFactor_
-                        |> round
                         |> (+) (negate pitchButtonSizeValue)
 
                 ( Horizontal, LowerBoundary ) ->
@@ -517,7 +513,6 @@ pitchButton model { degree, pitch, pitchAbove, pitchBelow, positionWithinRange, 
                         pitchAbove
                         |> Maybe.withDefault 0
                         |> (*) scalingFactor_
-                        |> round
                         |> (+) (negate pitchButtonSizeValue)
 
                 ( Horizontal, Within ) ->
@@ -526,7 +521,6 @@ pitchButton model { degree, pitch, pitchAbove, pitchBelow, positionWithinRange, 
                         pitchBelow
                         |> Maybe.withDefault 0
                         |> (*) scalingFactor_
-                        |> round
                         |> (+) (negate pitchButtonSizeValue)
 
                 ( Vertical, UpperBoundary ) ->
@@ -538,14 +532,13 @@ pitchButton model { degree, pitch, pitchAbove, pitchBelow, positionWithinRange, 
                         pitchBelow
                         |> Maybe.withDefault 0
                         |> (*) scalingFactor_
-                        |> round
                         |> (+) (negate pitchButtonSizeValue)
 
                 ( _, Above ) ->
                     0
 
         pitchButtonSizeValue =
-            pitchButtonSize model.layout // 2
+            pitchButtonSize model.layout / 2
     in
     button
         [ onClick <|
@@ -582,7 +575,7 @@ pitchButtonSizeClass =
     class "w-12 h-12 sm:w-16 sm:h-16 text-xl sm:text-3xl"
 
 
-pitchButtonSize : LayoutData -> Int
+pitchButtonSize : LayoutData -> Float
 pitchButtonSize layoutData =
     if layoutData.viewport.viewport.width < 640 then
         48

--- a/src/View/PitchSpace.elm
+++ b/src/View/PitchSpace.elm
@@ -192,14 +192,14 @@ scalingFactor layoutData rangeInMoria =
             pitchButtonSize layoutData |> toFloat
     in
     case layoutFor layoutData of
-        Portrait ->
+        Vertical ->
             (layoutData.viewport.viewport.height
                 - max layoutData.pitchSpace.element.y 128
                 - marginForButton
             )
                 / toFloat rangeInMoria
 
-        Landscape ->
+        Horizontal ->
             (layoutData.pitchSpace.element.width
                 - marginForButton
             )
@@ -220,12 +220,12 @@ view model =
          , Attr.attributeIf model.showSpacing Styles.border
          ]
             ++ (case layoutFor model.layout of
-                    Portrait ->
+                    Vertical ->
                         [ Styles.flexRow
                         , class "my-8"
                         ]
 
-                    Landscape ->
+                    Horizontal ->
                         [ Styles.flexCol
                         , class "mx-8"
                         ]
@@ -247,13 +247,13 @@ the interval column. We'll have to see, though.
 listAttributes : LayoutData -> List (Html.Attribute Msg)
 listAttributes layoutData =
     case layoutFor layoutData of
-        Portrait ->
+        Vertical ->
             [ class "flex flex-col-reverse justify-end w-36 mx-4"
 
             -- , Styles.height (truncate layoutData.viewport.viewport.height - 200)
             ]
 
-        Landscape ->
+        Horizontal ->
             [ Styles.flexRowCentered
             , class "h-24 w-full my-4"
             ]
@@ -332,10 +332,10 @@ viewInterval model rangeInMoria interval =
         , class <| positionString position
         , Styles.flexRowCentered
         , case layout of
-            Portrait ->
+            Vertical ->
                 Styles.height size
 
-            Landscape ->
+            Horizontal ->
                 Styles.width size
         , Styles.transition
         , Attr.attributeIf (positionIsVisible position) Styles.border
@@ -489,10 +489,10 @@ viewPitch model rangeInMoria degree =
         , Attr.attributeIf showSpacingDetails Styles.border
         , attributeIfVisible Styles.flexCol
         , case layout of
-            Portrait ->
+            Vertical ->
                 Styles.height size
 
-            Landscape ->
+            Horizontal ->
                 Styles.width size
         ]
         [ viewIfLazy (positionIsVisible positionWithinRange)
@@ -536,7 +536,7 @@ pitchButton model { degree, pitch, pitchAbove, pitchBelow, positionWithinRange, 
                 ( _, Below ) ->
                     0
 
-                ( Portrait, LowerBoundary ) ->
+                ( Vertical, LowerBoundary ) ->
                     Maybe.map
                         (\above -> toFloat (above - pitch) / 2)
                         pitchAbove
@@ -545,10 +545,10 @@ pitchButton model { degree, pitch, pitchAbove, pitchBelow, positionWithinRange, 
                         |> round
                         |> (+) (negate pitchButtonSizeValue)
 
-                ( Landscape, LowerBoundary ) ->
+                ( Horizontal, LowerBoundary ) ->
                     negate pitchButtonSizeValue
 
-                ( Portrait, Within ) ->
+                ( Vertical, Within ) ->
                     Maybe.map
                         (\above -> toFloat (above - pitch) / 2)
                         pitchAbove
@@ -557,7 +557,7 @@ pitchButton model { degree, pitch, pitchAbove, pitchBelow, positionWithinRange, 
                         |> round
                         |> (+) (negate pitchButtonSizeValue)
 
-                ( Landscape, Within ) ->
+                ( Horizontal, Within ) ->
                     Maybe.map
                         (\below -> toFloat (pitch - below) / 2)
                         pitchBelow
@@ -566,10 +566,10 @@ pitchButton model { degree, pitch, pitchAbove, pitchBelow, positionWithinRange, 
                         |> round
                         |> (+) (negate pitchButtonSizeValue)
 
-                ( Portrait, UpperBoundary ) ->
+                ( Vertical, UpperBoundary ) ->
                     negate pitchButtonSizeValue
 
-                ( Landscape, UpperBoundary ) ->
+                ( Horizontal, UpperBoundary ) ->
                     Maybe.map
                         (\below -> toFloat (pitch - below) / 2)
                         pitchBelow
@@ -595,10 +595,10 @@ pitchButton model { degree, pitch, pitchAbove, pitchBelow, positionWithinRange, 
         , class "rounded-full hover:z-10 cursor-pointer relative pb-8"
         , Styles.transition
         , case layoutFor model.layout of
-            Portrait ->
+            Vertical ->
                 Styles.top position
 
-            Landscape ->
+            Horizontal ->
                 Styles.left position
         , classList
             [ ( "bg-red-200", isCurrentPitch )


### PR DESCRIPTION
Rewrite of pitch space (intervals and pitch buttons) to enable responsive rendering in both horizontal and vertical layouts.

- Default layout is the vertical orientation. This can automatically switch to the horizontal layout when the viewport is short (presumably on a mobile device) and when the viewport is significantly wider than it is tall (i.e., landscape orientation). Users can also manually select one or the other.
- Created Styles module for common Tailwind class combinations and style attribute helpers.
- Added range controls, allowing the user to select the visible range.

## TODOs

### Done
- [x] Use rounded floats for style attributes
- [x] mouse-out of pitch column for setting movement to None

### For future work
- [ ] create a minimum for the vertical space to enable scrolling
- [ ] martyria display at bottom of range appears off