### PR TITLE
Add Ison

### DIFF
--- a/src/Model/PitchState.elm
+++ b/src/Model/PitchState.elm
@@ -1,6 +1,14 @@
-module Model.PitchState exposing (PitchState, initialPitchState)
+module Model.PitchState exposing
+    ( PitchState, initialPitchState
+    , IsonStatus(..), ison
+    )
 
 {-| User-controlled pitch state.
+
+@docs PitchState, initialPitchState
+
+@docs IsonStatus, ison
+
 -}
 
 import Byzantine.Degree exposing (Degree)
@@ -9,6 +17,7 @@ import Movement exposing (Movement)
 
 type alias PitchState =
     { currentPitch : Maybe Degree
+    , ison : IsonStatus
     , proposedMovement : Movement
     }
 
@@ -16,5 +25,31 @@ type alias PitchState =
 initialPitchState : PitchState
 initialPitchState =
     { currentPitch = Nothing
+    , ison = NoIson
     , proposedMovement = Movement.None
     }
+
+
+{-| A `Selecting` variant for `IsonStatus` is used to indicate when a user is in
+the process of changing the current ison. The `Maybe Degree` payload represents
+the current ison, which enables continuous pitch when changing the ison.
+-}
+type IsonStatus
+    = NoIson
+    | SelectingIson (Maybe Degree)
+    | Selected Degree
+
+
+{-| Current pitch of the ison status.
+-}
+ison : PitchState -> Maybe Degree
+ison pitchState =
+    case pitchState.ison of
+        NoIson ->
+            Nothing
+
+        SelectingIson maybeDegree ->
+            maybeDegree
+
+        Selected degree ->
+            Just degree

--- a/src/Styles.elm
+++ b/src/Styles.elm
@@ -165,7 +165,7 @@ borderRounded =
 -}
 buttonClass : Html.Attribute msg
 buttonClass =
-    class "bg-gray-200 my-2 py-1 px-3 rounded-md"
+    class "bg-gray-200 hover:bg-gray-300 my-2 py-1 px-3 rounded-md cursor-pointer"
 
 
 {-| `class "transition-all duration-800"`

--- a/src/Update.elm
+++ b/src/Update.elm
@@ -211,9 +211,16 @@ update msg model =
                     )
 
                 setAndFocus degree =
-                    ( updatePitchState
-                        (\pitchState -> { pitchState | currentPitch = Just degree })
-                        model
+                    ( case model.pitchState.ison of
+                        PitchState.SelectingIson _ ->
+                            updatePitchState
+                                (\pitchState -> { pitchState | ison = PitchState.Selected degree })
+                                model
+
+                        _ ->
+                            updatePitchState
+                                (\pitchState -> { pitchState | currentPitch = Just degree })
+                                model
                     , Degree.toString degree |> (++) "p_" |> Dom.focus |> Task.attempt DomResult
                     )
             in
@@ -312,6 +319,40 @@ update msg model =
 
                 "z" ->
                     setAndFocus Zo_
+
+                "i" ->
+                    case model.pitchState.ison of
+                        PitchState.NoIson ->
+                            ( updatePitchState
+                                (\pitchState ->
+                                    { pitchState | ison = PitchState.SelectingIson Nothing }
+                                )
+                                model
+                            , Task.attempt DomResult (Dom.focus "select-ison-button")
+                            )
+
+                        PitchState.SelectingIson (Just ison) ->
+                            ( updatePitchState
+                                (\pitchState ->
+                                    { pitchState
+                                        | ison = PitchState.Selected ison
+                                    }
+                                )
+                                model
+                            , Cmd.none
+                            )
+
+                        PitchState.SelectingIson Nothing ->
+                            ( updatePitchState
+                                (\pitchState ->
+                                    { pitchState | ison = PitchState.NoIson }
+                                )
+                                model
+                            , Task.attempt DomResult (Dom.focus "select-ison-button")
+                            )
+
+                        PitchState.Selected _ ->
+                            ( model, Cmd.none )
 
                 _ ->
                     ( model, Cmd.none )

--- a/src/Update.elm
+++ b/src/Update.elm
@@ -10,7 +10,7 @@ import Model exposing (Modal, Model)
 import Model.AudioSettings exposing (AudioSettings)
 import Model.LayoutData exposing (LayoutData, LayoutSelection)
 import Model.ModeSettings exposing (ModeSettings)
-import Model.PitchState as PitchState exposing (PitchState)
+import Model.PitchState as PitchState exposing (IsonStatus(..), PitchState)
 import Movement exposing (Movement)
 import Platform.Cmd as Cmd
 import Task
@@ -27,6 +27,7 @@ type Msg
     | SelectPitch (Maybe Degree) (Maybe Movement)
     | SelectProposedMovement Movement
     | SetGain Float
+    | SetIson IsonStatus
     | SetLayout LayoutSelection
     | SetPitchStandard PitchStandard
     | SetRangeStart String
@@ -84,15 +85,18 @@ update msg model =
             )
 
         SelectPitch pitch maybeMovement ->
-            ( setPitchState
-                { currentPitch = pitch
-                , proposedMovement =
-                    if Maybe.isJust pitch then
-                        Maybe.withDefault model.pitchState.proposedMovement maybeMovement
+            ( updatePitchState
+                (\pitchState ->
+                    { pitchState
+                        | currentPitch = pitch
+                        , proposedMovement =
+                            if Maybe.isJust pitch then
+                                Maybe.withDefault model.pitchState.proposedMovement maybeMovement
 
-                    else
-                        Movement.None
-                }
+                            else
+                                Movement.None
+                    }
+                )
                 model
             , Cmd.none
             )
@@ -107,6 +111,13 @@ update msg model =
         SetGain gain ->
             ( updateAudioSettings
                 (\audioSettings -> { audioSettings | gain = clamp 0 1 gain })
+                model
+            , Cmd.none
+            )
+
+        SetIson ison ->
+            ( updatePitchState
+                (\pitchState -> { pitchState | ison = ison })
                 model
             , Cmd.none
             )

--- a/src/View.elm
+++ b/src/View.elm
@@ -86,21 +86,24 @@ backdrop model =
 
 audio : Model -> Html msg
 audio model =
+    let
+        frequency degree =
+            Pitch.frequency model.audioSettings.pitchStandard
+                model.audioSettings.register
+                model.modeSettings.scale
+                degree
+                |> String.fromFloat
+    in
     Html.node "chant-engine"
         [ model.audioSettings.gain
             |> String.fromFloat
             |> Attr.attribute "gain"
-        , case model.pitchState.currentPitch of
-            Nothing ->
-                Attr.empty
-
-            Just pitch ->
-                Pitch.frequency model.audioSettings.pitchStandard
-                    model.audioSettings.register
-                    model.modeSettings.scale
-                    pitch
-                    |> String.fromFloat
-                    |> Attr.attribute "melos"
+        , Maybe.unwrap Attr.empty
+            (Attr.attribute "melos" << frequency)
+            model.pitchState.currentPitch
+        , Maybe.unwrap Attr.empty
+            (Attr.attribute "ison" << frequency)
+            (PitchState.ison model.pitchState)
         ]
         []
 

--- a/src/View.elm
+++ b/src/View.elm
@@ -348,6 +348,7 @@ isonButton : PitchState -> Html Msg
 isonButton pitchState =
     button
         [ Styles.buttonClass
+        , id "select-ison-button"
         , onClick
             (SetIson
                 (case pitchState.ison of

--- a/src/View.elm
+++ b/src/View.elm
@@ -100,7 +100,7 @@ audio model =
                     model.modeSettings.scale
                     pitch
                     |> String.fromFloat
-                    |> Attr.attribute "ison"
+                    |> Attr.attribute "melos"
         ]
         []
 

--- a/src/View/PitchSpace.elm
+++ b/src/View/PitchSpace.elm
@@ -18,7 +18,7 @@ import Maybe.Extra as Maybe
 import Model exposing (Model)
 import Model.LayoutData exposing (Layout(..), LayoutData, layoutFor)
 import Model.ModeSettings exposing (ModeSettings)
-import Model.PitchState exposing (PitchState)
+import Model.PitchState exposing (IsonStatus(..), PitchState)
 import Movement exposing (Movement(..))
 import Round
 import Styles
@@ -498,6 +498,15 @@ pitchButton { layoutData, modeSettings, pitchState } { degree, pitch, pitchAbove
         isCurrentPitch =
             Just degree == pitchState.currentPitch
 
+        canBeSelectedAsIson =
+            -- this should be made a bit more robust once modal logic gets built out.
+            case pitchState.ison of
+                SelectingIson _ ->
+                    True
+
+                _ ->
+                    False
+
         layout =
             layoutFor layoutData
 
@@ -549,7 +558,10 @@ pitchButton { layoutData, modeSettings, pitchState } { degree, pitch, pitchAbove
     in
     button
         [ onClick <|
-            if isCurrentPitch then
+            if canBeSelectedAsIson then
+                SetIson (Selected degree)
+
+            else if isCurrentPitch then
                 SelectPitch Nothing Nothing
 
             else
@@ -567,6 +579,8 @@ pitchButton { layoutData, modeSettings, pitchState } { degree, pitch, pitchAbove
             [ ( "bg-red-200", isCurrentPitch )
             , ( "hover:text-green-700 bg-slate-200 hover:bg-slate-300 opacity-75 hover:opacity-100", not isCurrentPitch )
             , ( "text-green-700 bg-slate-300 z-10", Movement.toDegree pitchState.proposedMovement == Just degree )
+            , ( "border-2 border-blue-700", canBeSelectedAsIson )
+            , ( "border-2 border-transparent", not canBeSelectedAsIson )
             ]
         ]
         [ ByzHtmlMartyria.viewWithAttributes

--- a/src/View/PitchSpace.elm
+++ b/src/View/PitchSpace.elm
@@ -71,6 +71,30 @@ view { layoutData, modeSettings, pitchState } =
         ]
 
 
+{-| Includes both state elements passed in from the model and also derived
+values that are calculated from the state.
+-}
+type alias Params =
+    { layout : Layout
+    , layoutData : LayoutData
+    , modeSettings : ModeSettings
+    , pitchButtonSize : Float
+    , pitchState : PitchState
+    , scalingFactor : Float
+    , visibleRange : { start : Degree, end : Degree }
+    }
+
+
+type alias PitchDisplayParams =
+    { degree : Degree
+    , pitch : Int
+    , pitchAbove : Maybe Int
+    , pitchBelow : Maybe Int
+    , positionWithinRange : PositionWithinVisibleRange
+    , scalingFactor : Float
+    }
+
+
 {-| This feels potentially fragile.
 
 TODO: we'll need some sort of minimum for the portrait to enable scrolling on
@@ -128,34 +152,6 @@ calculatePitchButtonSize layoutData =
 
     else
         64
-
-
-
--- HELPER TYPES AND FUNCTIONS
-
-
-{-| Includes both state elements passed in from the model and also derived
-values that are calculated from the state.
--}
-type alias Params =
-    { layout : Layout
-    , layoutData : LayoutData
-    , modeSettings : ModeSettings
-    , pitchButtonSize : Float
-    , pitchState : PitchState
-    , scalingFactor : Float
-    , visibleRange : { start : Degree, end : Degree }
-    }
-
-
-type alias PitchDisplayParams =
-    { degree : Degree
-    , pitch : Int
-    , pitchAbove : Maybe Int
-    , pitchBelow : Maybe Int
-    , positionWithinRange : PositionWithinVisibleRange
-    , scalingFactor : Float
-    }
 
 
 

--- a/src/View/PitchSpace.elm
+++ b/src/View/PitchSpace.elm
@@ -41,6 +41,7 @@ view { layoutData, modeSettings, pitchState } =
             , layoutData = layoutData
             , modeSettings = modeSettings
             , pitchState = pitchState
+            , visibleRange = calculateVisibleRange modeSettings pitchState
             }
     in
     div
@@ -75,14 +76,11 @@ minor tweaks.
 
 -}
 calculateScalingFactor : Params -> Float
-calculateScalingFactor ({ layout, layoutData, modeSettings } as params) =
+calculateScalingFactor { layout, layoutData, modeSettings, visibleRange } =
     let
-        { start, end } =
-            visibleRange params
-
         visibleRangeInMoria =
-            Pitch.pitchPosition modeSettings.scale end
-                - Pitch.pitchPosition modeSettings.scale start
+            Pitch.pitchPosition modeSettings.scale visibleRange.end
+                - Pitch.pitchPosition modeSettings.scale visibleRange.start
 
         marginForButton =
             calculatePitchButtonSize layoutData
@@ -134,12 +132,16 @@ calculatePitchButtonSize layoutData =
 -- HELPER TYPES AND FUNCTIONS
 
 
+{-| Includes both state elements passed in from the model and also derived
+values that are calculated from the state.
+-}
 type alias Params =
     { layout : Layout
     , layoutData : LayoutData
     , modeSettings : ModeSettings
     , pitchButtonSize : Float
     , pitchState : PitchState
+    , visibleRange : { start : Degree, end : Degree }
     }
 
 
@@ -161,8 +163,8 @@ type alias PitchDisplayParams =
 user-set) start and stop positions to include the current pitch. (We may want to
 consider additional limits as well.)
 -}
-visibleRange : Params -> { start : Degree, end : Degree }
-visibleRange { modeSettings, pitchState } =
+calculateVisibleRange : ModeSettings -> PitchState -> { start : Degree, end : Degree }
+calculateVisibleRange modeSettings pitchState =
     case pitchState.currentPitch of
         Just currentPitch ->
             { start =
@@ -228,14 +230,11 @@ viewIntervals params =
 intervalsWithVisibility : Params -> List ( Interval, PositionWithinVisibleRange )
 intervalsWithVisibility params =
     let
-        { start, end } =
-            visibleRange params
-
         lowerBoundIndex =
-            Degree.indexOf start
+            Degree.indexOf params.visibleRange.start
 
         upperBoundIndex =
-            Degree.indexOf end
+            Degree.indexOf params.visibleRange.end
 
         visibility interval =
             let
@@ -401,14 +400,11 @@ viewPitches params =
 pitchesWithVisibility : Params -> List ( Degree, PositionWithinVisibleRange )
 pitchesWithVisibility params =
     let
-        { start, end } =
-            visibleRange params
-
         lowerBoundIndex =
-            Degree.indexOf start
+            Degree.indexOf params.visibleRange.start
 
         upperBoundIndex =
-            Degree.indexOf end
+            Degree.indexOf params.visibleRange.end
 
         visibility pitchIndex =
             if pitchIndex < lowerBoundIndex then

--- a/src/chant_engine.ts
+++ b/src/chant_engine.ts
@@ -1,6 +1,17 @@
 const crossFadeSeconds = 0.2;
 const crossFadeMilliseconds = crossFadeSeconds * 1000;
 
+const localDev = true;
+const debugging = false;
+function devLog(x: any) {
+    if (localDev) {
+        if (debugging) {
+            debugger;
+        }
+        console.log(x);
+    }
+}
+
 class ChantEngine extends HTMLElement {
     private audioContext: AudioContext;
     private mainGainNode: GainNode;
@@ -23,11 +34,11 @@ class ChantEngine extends HTMLElement {
     }
 
     connectedCallback() {
-        // console.log("connecting...");
+        devLog("connecting chant engine element...");
     }
 
     disconnectedCallback() {
-        // console.log("disconnecting...");
+        devLog("disconnecting chant engine...");
         this.stopTone(this.melos);
         this.audioContext.close();
     }
@@ -52,15 +63,15 @@ class ChantEngine extends HTMLElement {
                 if (this.melos) {
                     // TODO: if oldFreq == newFreq, some sort of re-articulation
                     if (newFreq) {
-                        // console.log(`changing frequency to ${newFreq}`);
+                        devLog(`changing frequency to ${newFreq}`);
                         this.melos.frequency.value = newFreq;
                     } else {
-                        // console.log("stopping tone");
+                        devLog("stopping tone");
                         this.stopTone(this.melos);
                         this.melos = undefined;
                     }
                 } else {
-                    // console.log("playing tone");
+                    devLog("playing tone");
                     this.melos = this.playTone(newFreq);
                 }
                 break;
@@ -88,7 +99,7 @@ class ChantEngine extends HTMLElement {
         )
             return undefined;
 
-        // console.log(`playing ${freq}`);
+        devLog(`playing ${freq}`);
 
         const osc = this.audioContext.createOscillator();
         osc.frequency.value = freq;
@@ -109,13 +120,13 @@ class ChantEngine extends HTMLElement {
         gain.connect(this.mainGainNode);
 
         osc.start();
-        // console.log(osc)
+        devLog(osc);
         return osc;
     }
 
     private stopTone(osc: OscillatorNode | undefined): void {
         if (osc == null) return;
-        console.log(`stopping ${osc.frequency.value}`);
+        devLog(`stopping ${osc.frequency.value}`);
 
         const now = this.audioContext.currentTime;
         // const gain = this.audioContext.createGain();
@@ -130,7 +141,7 @@ class ChantEngine extends HTMLElement {
         osc.stop(now + crossFadeSeconds);
 
         // setTimeout(() => {
-        //     console.log("stopping now?")
+        //     devLog("stopping now?")
         //     osc.stop();
         // }, crossFadeMilliseconds + 1)
         // setTimeout

--- a/src/chant_engine.ts
+++ b/src/chant_engine.ts
@@ -1,7 +1,7 @@
 const crossFadeSeconds = 0.2;
 const crossFadeMilliseconds = crossFadeSeconds * 1000;
 
-const localDev = true;
+const localDev = false;
 const debugging = false;
 function devLog(x: any) {
     if (localDev) {
@@ -15,6 +15,7 @@ function devLog(x: any) {
 class ChantEngine extends HTMLElement {
     private audioContext: AudioContext;
     private mainGainNode: GainNode;
+    private ison: OscillatorNode | undefined;
     private melos: OscillatorNode | undefined;
 
     static maxFrequency: number = 18000;
@@ -39,6 +40,7 @@ class ChantEngine extends HTMLElement {
 
     disconnectedCallback() {
         devLog("disconnecting chant engine...");
+        this.stopTone(this.ison);
         this.stopTone(this.melos);
         this.audioContext.close();
     }
@@ -57,31 +59,41 @@ class ChantEngine extends HTMLElement {
                 this.mainGainNode.gain.value = Number(newValue);
                 break;
 
-            case "melos":
-                const oldFreq = parseFloat(oldValue);
-                const newFreq = parseFloat(newValue);
-                if (this.melos) {
-                    // TODO: if oldFreq == newFreq, some sort of re-articulation
-                    if (newFreq) {
-                        devLog(`changing frequency to ${newFreq}`);
-                        this.melos.frequency.value = newFreq;
+            case "ison":
+                const oldIsonFreq = parseFloat(oldValue);
+                const newIsonFreq = parseFloat(newValue);
+                if (this.ison) {
+                    if (newIsonFreq) {
+                        devLog(`changing ison frequency to ${newIsonFreq}`);
+                        this.ison.frequency.value = newIsonFreq;
                     } else {
-                        devLog("stopping tone");
+                        devLog("stopping ison tone");
+                        this.stopTone(this.ison);
+                        this.ison = undefined;
+                    }
+                } else {
+                    devLog("playing ison tone");
+                    this.ison = this.playTone(newIsonFreq);
+                }
+                break;
+
+            case "melos":
+                const oldMelosFreq = parseFloat(oldValue);
+                const newMelosFreq = parseFloat(newValue);
+                if (this.melos) {
+                    if (newMelosFreq) {
+                        devLog(`changing melos frequency to ${newMelosFreq}`);
+                        this.melos.frequency.value = newMelosFreq;
+                    } else {
+                        devLog("stopping melos tone");
                         this.stopTone(this.melos);
                         this.melos = undefined;
                     }
                 } else {
-                    devLog("playing tone");
-                    this.melos = this.playTone(newFreq);
+                    devLog("playing melos tone");
+                    this.melos = this.playTone(newMelosFreq);
                 }
                 break;
-
-            // case "melos":
-            //     if (this.melos) {
-            //         this.melos.stop();
-            //     }
-            //     this.melos = this.playTone(newValue);
-            //     break;
         }
     }
 

--- a/src/chant_engine.ts
+++ b/src/chant_engine.ts
@@ -4,7 +4,7 @@ const crossFadeMilliseconds = crossFadeSeconds * 1000;
 class ChantEngine extends HTMLElement {
     private audioContext: AudioContext;
     private mainGainNode: GainNode;
-    private ison: OscillatorNode | undefined;
+    private melos: OscillatorNode | undefined;
 
     static maxFrequency: number = 18000;
     static minFrequency: number = 32;
@@ -28,7 +28,7 @@ class ChantEngine extends HTMLElement {
 
     disconnectedCallback() {
         // console.log("disconnecting...");
-        this.stopTone(this.ison);
+        this.stopTone(this.melos);
         this.audioContext.close();
     }
 
@@ -46,22 +46,22 @@ class ChantEngine extends HTMLElement {
                 this.mainGainNode.gain.value = Number(newValue);
                 break;
 
-            case "ison":
+            case "melos":
                 const oldFreq = parseFloat(oldValue);
                 const newFreq = parseFloat(newValue);
-                if (this.ison) {
+                if (this.melos) {
                     // TODO: if oldFreq == newFreq, some sort of re-articulation
                     if (newFreq) {
-                        console.log(`changing frequency to ${newFreq}`);
-                        this.ison.frequency.value = newFreq;
+                        // console.log(`changing frequency to ${newFreq}`);
+                        this.melos.frequency.value = newFreq;
                     } else {
-                        console.log("stopping tone");
-                        this.stopTone(this.ison);
-                        this.ison = undefined;
+                        // console.log("stopping tone");
+                        this.stopTone(this.melos);
+                        this.melos = undefined;
                     }
                 } else {
-                    console.log("playing tone");
-                    this.ison = this.playTone(newFreq);
+                    // console.log("playing tone");
+                    this.melos = this.playTone(newFreq);
                 }
                 break;
 
@@ -88,7 +88,7 @@ class ChantEngine extends HTMLElement {
         )
             return undefined;
 
-        console.log(`playing ${freq}`);
+        // console.log(`playing ${freq}`);
 
         const osc = this.audioContext.createOscillator();
         osc.frequency.value = freq;


### PR DESCRIPTION
Add the ability to select an ison pitch.

Includes some refactors of the pitch space view code. The general goal is to avoid repeated calculations of values that are derived from the top-level state and that are consistent for all individual items within, for example, the list of intervals.