### PR TITLE
Performance optimization: lazy rendering

### DIFF
--- a/src/Byzantine/Accidental.elm
+++ b/src/Byzantine/Accidental.elm
@@ -1,4 +1,4 @@
-module Byzantine.Accidental exposing (Accidental(..), all, lower, moriaAdjustment, raise, toString)
+module Byzantine.Accidental exposing (Accidental(..), all, fromString, lower, moriaAdjustment, raise, toString)
 
 
 type Accidental
@@ -115,3 +115,37 @@ toString accidental =
 
     else
         String.fromInt val
+
+
+{-| Convert a string representation back to an Accidental. String must be in the
+format "+N" or "-N" where N is a valid moria adjustment (2, 4, 6, or 8).
+-}
+fromString : String -> Result String Accidental
+fromString str =
+    case str of
+        "+2" ->
+            Ok Sharp2
+
+        "+4" ->
+            Ok Sharp4
+
+        "+6" ->
+            Ok Sharp6
+
+        "+8" ->
+            Ok Sharp8
+
+        "-2" ->
+            Ok Flat2
+
+        "-4" ->
+            Ok Flat4
+
+        "-6" ->
+            Ok Flat6
+
+        "-8" ->
+            Ok Flat8
+
+        _ ->
+            Err ("Invalid accidental: " ++ str)

--- a/src/Byzantine/Degree.elm
+++ b/src/Byzantine/Degree.elm
@@ -1,4 +1,4 @@
-module Byzantine.Degree exposing (Degree(..), baseOctave, gamut, gamutList, getInterval, indexOf, range, step, text, toString, toStringGreek)
+module Byzantine.Degree exposing (Degree(..), baseOctave, fromString, gamut, gamutList, getInterval, indexOf, range, step, text, toString, toStringGreek)
 
 import Array exposing (Array)
 import Byzantine.Scale exposing (Scale(..))
@@ -243,3 +243,58 @@ baseOctave scale =
 
         HardChromatic ->
             octaveFrom Pa
+
+
+{-| Convert a string representation back to a Degree. Returns an Err if the
+string doesn't match a valid degree name.
+-}
+fromString : String -> Result String Degree
+fromString str =
+    case str of
+        "GA" ->
+            Ok GA
+
+        "DI" ->
+            Ok DI
+
+        "KE" ->
+            Ok KE
+
+        "Zo" ->
+            Ok Zo
+
+        "Ni" ->
+            Ok Ni
+
+        "Pa" ->
+            Ok Pa
+
+        "Bou" ->
+            Ok Bou
+
+        "Ga" ->
+            Ok Ga
+
+        "Di" ->
+            Ok Di
+
+        "Ke" ->
+            Ok Ke
+
+        "Zo_" ->
+            Ok Zo_
+
+        "Ni_" ->
+            Ok Ni_
+
+        "Pa_" ->
+            Ok Pa_
+
+        "Bou_" ->
+            Ok Bou_
+
+        "Ga_" ->
+            Ok Ga_
+
+        _ ->
+            Err ("Invalid degree name: " ++ str)

--- a/src/Byzantine/Pitch.elm
+++ b/src/Byzantine/Pitch.elm
@@ -4,7 +4,9 @@ module Byzantine.Pitch exposing
     , unwrapDegree, unwrapAccidental
     , isInflected, isValidInflection, toString
     , pitchPosition, pitchPositions
-    , PitchStandard(..), Register(..), frequency
+    , PitchStandard(..), pitchStandardToString
+    , Register(..), registerToString
+    , frequency
     , Interval, intervals, intervalsFrom, getInterval
     )
 
@@ -43,7 +45,20 @@ attractions and inflections.
 
 # Frequency
 
-@docs PitchStandard, Register, frequency
+
+## PitchStandard
+
+@docs PitchStandard, pitchStandardToString
+
+
+## Register
+
+@docs Register, registerToString
+
+
+## Frequency
+
+@docs frequency
 
 
 # Intervals
@@ -328,9 +343,29 @@ type PitchStandard
     | Ke440
 
 
+pitchStandardToString : PitchStandard -> String
+pitchStandardToString pitchStandard =
+    case pitchStandard of
+        Ni256 ->
+            "Ni256"
+
+        Ke440 ->
+            "Ke440"
+
+
 type Register
     = Treble
     | Bass
+
+
+registerToString : Register -> String
+registerToString register =
+    case register of
+        Treble ->
+            "Treble"
+
+        Bass ->
+            "Bass"
 
 
 {-| Frequency relative to a fixed pitch for Natural Di, according to the given pitch

--- a/src/Byzantine/Pitch.elm
+++ b/src/Byzantine/Pitch.elm
@@ -4,9 +4,9 @@ module Byzantine.Pitch exposing
     , unwrapDegree, unwrapAccidental
     , isInflected, isValidInflection, toString
     , pitchPosition, pitchPositions
+    , frequency
     , PitchStandard(..), pitchStandardToString
     , Register(..), registerToString
-    , frequency
     , Interval, intervals, intervalsFrom, getInterval
     )
 
@@ -45,6 +45,8 @@ attractions and inflections.
 
 # Frequency
 
+@docs frequency
+
 
 ## PitchStandard
 
@@ -54,11 +56,6 @@ attractions and inflections.
 ## Register
 
 @docs Register, registerToString
-
-
-## Frequency
-
-@docs frequency
 
 
 # Intervals

--- a/src/Model/PitchState.elm
+++ b/src/Model/PitchState.elm
@@ -46,9 +46,9 @@ type IsonStatus
 
 {-| Current pitch of the ison status.
 -}
-ison : PitchState -> Maybe Pitch
-ison pitchState =
-    case pitchState.ison of
+ison : IsonStatus -> Maybe Pitch
+ison isonStatus =
+    case isonStatus of
         NoIson ->
             Nothing
 

--- a/src/RadioFieldset.elm
+++ b/src/RadioFieldset.elm
@@ -3,7 +3,7 @@ module RadioFieldset exposing (Config, view)
 import Html exposing (Html, div, fieldset, input, label, legend, text)
 import Html.Attributes as Attr exposing (checked, class, type_)
 import Html.Events exposing (onClick)
-import Html.Lazy
+import Html.Lazy exposing (lazy3)
 import String.Extra exposing (dasherize)
 import Styles
 
@@ -13,24 +13,20 @@ type alias Config a msg =
     , legendText : String
     , onSelect : a -> msg
     , options : List a
-    , selected : a
     , viewItem : Maybe (a -> Html msg)
     }
 
 
-view : Config a msg -> Html msg
-view config =
-    Html.Lazy.lazy
-        (\config_ ->
-            List.map (radioOption config_) config_.options
-                |> (::) (legend [ class "px-1" ] [ text config_.legendText ])
-                |> fieldset [ Styles.borderRounded, class "px-2 pb-1 mb-2" ]
-        )
-        config
+view : Config a msg -> a -> Html msg
+view config selected =
+    config.options
+        |> List.map (\option -> lazy3 radioOption config (selected == option) option)
+        |> (::) (legend [ class "px-1" ] [ text config.legendText ])
+        |> fieldset [ Styles.borderRounded, class "px-2 pb-1 mb-2" ]
 
 
-radioOption : Config a msg -> a -> Html msg
-radioOption config option =
+radioOption : Config a msg -> Bool -> a -> Html msg
+radioOption config isSelected option =
     let
         itemName =
             config.itemToString option
@@ -44,7 +40,7 @@ radioOption config option =
             , Attr.name ("radio-" ++ dasherize config.legendText)
             , Attr.id id
             , class "cursor-pointer m-2"
-            , checked (config.selected == option)
+            , checked isSelected
             , onClick (config.onSelect option)
             ]
             []

--- a/src/View.elm
+++ b/src/View.elm
@@ -14,6 +14,7 @@ import Html.Attributes as Attr exposing (class, classList, id, type_)
 import Html.Attributes.Extra as Attr
 import Html.Events exposing (onClick, onInput)
 import Html.Extra exposing (viewIf)
+import Html.Lazy
 import Icons
 import Json.Decode exposing (Decoder)
 import List.Extra as List
@@ -43,7 +44,11 @@ view : Model -> Html Msg
 view model =
     div
         [ class "p-4" ]
-        [ audio model
+        [ Html.Lazy.lazy4 chantEngineNode
+            model.audioSettings
+            model.modeSettings.scale
+            model.pitchState.currentPitch
+            (PitchState.ison model.pitchState)
         , backdrop model
         , header model
         , viewModal model
@@ -86,26 +91,26 @@ backdrop model =
         []
 
 
-audio : Model -> Html msg
-audio model =
+chantEngineNode : AudioSettings -> Scale -> Maybe Pitch -> Maybe Pitch -> Html msg
+chantEngineNode audioSettings scale currentPitch currentIson =
     let
         frequency pitch =
-            Pitch.frequency model.audioSettings.pitchStandard
-                model.audioSettings.register
-                model.modeSettings.scale
+            Pitch.frequency audioSettings.pitchStandard
+                audioSettings.register
+                scale
                 pitch
                 |> String.fromFloat
     in
     Html.node "chant-engine"
-        [ model.audioSettings.gain
+        [ audioSettings.gain
             |> String.fromFloat
             |> Attr.attribute "gain"
         , Maybe.unwrap Attr.empty
             (Attr.attribute "melos" << frequency)
-            model.pitchState.currentPitch
+            currentPitch
         , Maybe.unwrap Attr.empty
             (Attr.attribute "ison" << frequency)
-            (PitchState.ison model.pitchState)
+            currentIson
         ]
         []
 

--- a/src/View/PitchSpace.elm
+++ b/src/View/PitchSpace.elm
@@ -17,7 +17,6 @@ import Html.Attributes.Extra as Attr
 import Html.Events exposing (onClick, onFocus, onMouseEnter, onMouseLeave)
 import Html.Extra exposing (viewIf, viewIfLazy)
 import Maybe.Extra as Maybe
-import Model exposing (Model)
 import Model.LayoutData as LayoutData exposing (Layout(..), LayoutData)
 import Model.ModeSettings exposing (ModeSettings)
 import Model.PitchState as PitchState exposing (IsonStatus(..), PitchState)
@@ -31,8 +30,8 @@ import Update exposing (Msg(..))
 -- WRAPPER AND VIEW HELPERS
 
 
-view : Model -> Html Msg
-view { layoutData, modeSettings, pitchState } =
+view : LayoutData -> ModeSettings -> PitchState -> Html Msg
+view layoutData modeSettings pitchState =
     let
         layout =
             LayoutData.layoutFor layoutData

--- a/src/View/PitchSpace.elm
+++ b/src/View/PitchSpace.elm
@@ -530,7 +530,7 @@ viewPitch ({ layout, layoutData, modeSettings, scalingFactor } as params) ( pitc
             Attr.attributeIf (positionIsVisible positionWithinRange)
 
         isIson =
-            PitchState.ison params.pitchState == Just (Pitch.natural degree)
+            PitchState.ison params.pitchState.ison == Just (Pitch.natural degree)
     in
     li
         ([ Attr.id ("pitch-" ++ Degree.toString degree)

--- a/tests/Tests.elm
+++ b/tests/Tests.elm
@@ -161,3 +161,56 @@ accidentalBuilder =
                     accidentals
     in
     next [] |> List.reverse
+
+
+pitchTests : Test
+pitchTests =
+    describe "Pitch Tests"
+        [ describe "Encode/Decode Roundtrip Tests"
+            [ describe "Natural Pitches"
+                (List.concatMap
+                    (\scale ->
+                        List.map
+                            (\degree ->
+                                let
+                                    pitch =
+                                        Pitch.natural degree
+                                in
+                                test (Scale.name scale ++ " " ++ "Natural " ++ Pitch.toString pitch) <|
+                                    \_ ->
+                                        pitch
+                                            |> Pitch.encode
+                                            |> Pitch.decode scale
+                                            |> Expect.equal (Ok pitch)
+                            )
+                            Degree.gamutList
+                    )
+                    Scale.all
+                )
+            , describe "Inflected Pitches"
+                (List.concatMap
+                    (\scale ->
+                        List.concatMap
+                            (\degree ->
+                                List.filterMap
+                                    (\accidental ->
+                                        Pitch.inflected scale accidental degree
+                                            |> Result.toMaybe
+                                            |> Maybe.map
+                                                (\pitch ->
+                                                    test (Scale.name scale ++ " " ++ Pitch.toString pitch) <|
+                                                        \_ ->
+                                                            pitch
+                                                                |> Pitch.encode
+                                                                |> Pitch.decode scale
+                                                                |> Expect.equal (Ok pitch)
+                                                )
+                                    )
+                                    Accidental.all
+                            )
+                            Degree.gamutList
+                    )
+                    Scale.all
+                )
+            ]
+        ]


### PR DESCRIPTION
We might as well start setting things up to take advantage of lazy rendering. This could have significant performance implications once pitch tracking is set up, or for other possible playback features. This incorporates lazy rendering in places. Additional refactors will be needed to incorporate lazy rendering for more of the pitch space elements, but those will be more significant and might warrant some benchmarking. All changes in this PR should be relatively straightforward and cheap.