### PR TITLE
Create "Applied Accidentals" concept

### DIFF
--- a/src/Byzantine/Accidental.elm
+++ b/src/Byzantine/Accidental.elm
@@ -2,7 +2,8 @@ module Byzantine.Accidental exposing (Accidental(..), all, fromString, lower, mo
 
 
 type Accidental
-    = Sharp2
+    = Natural
+    | Sharp2
     | Sharp4
     | Sharp6
     | Sharp8
@@ -17,12 +18,15 @@ type Accidental
 -}
 all : List Accidental
 all =
-    [ Flat8, Flat6, Flat4, Flat2, Sharp2, Sharp4, Sharp6, Sharp8 ]
+    [ Flat8, Flat6, Flat4, Flat2, Natural, Sharp2, Sharp4, Sharp6, Sharp8 ]
 
 
 raise : Accidental -> Maybe Accidental
 raise accidental =
     case accidental of
+        Natural ->
+            Just Sharp2
+
         Sharp2 ->
             Just Sharp4
 
@@ -36,7 +40,7 @@ raise accidental =
             Nothing
 
         Flat2 ->
-            Nothing
+            Just Natural
 
         Flat4 ->
             Just Flat2
@@ -51,8 +55,11 @@ raise accidental =
 lower : Accidental -> Maybe Accidental
 lower accidental =
     case accidental of
+        Natural ->
+            Just Flat2
+
         Sharp2 ->
-            Nothing
+            Just Natural
 
         Sharp4 ->
             Just Sharp2
@@ -79,6 +86,9 @@ lower accidental =
 moriaAdjustment : Accidental -> Int
 moriaAdjustment accidental =
     case accidental of
+        Natural ->
+            0
+
         Sharp2 ->
             2
 
@@ -110,7 +120,10 @@ toString accidental =
         val =
             moriaAdjustment accidental
     in
-    if val > 0 then
+    if val == 0 then
+        "0"
+
+    else if val > 0 then
         "+" ++ String.fromInt val
 
     else
@@ -123,6 +136,9 @@ format "+N" or "-N" where N is a valid moria adjustment (2, 4, 6, or 8).
 fromString : String -> Result String Accidental
 fromString str =
     case str of
+        "0" ->
+            Ok Natural
+
         "+2" ->
             Ok Sharp2
 

--- a/src/Byzantine/ByzHtml/Accidental.elm
+++ b/src/Byzantine/ByzHtml/Accidental.elm
@@ -10,6 +10,9 @@ are not currently encoded here.
 
 <https://danielgarthur.github.io/byzhtml/#/component-list-neumes>
 
+TODO: consider how to represent Natural, since this emerges from a UI concern
+rather than from a notational one.
+
 -}
 view : Color -> Accidental -> Html msg
 view color accidental =
@@ -23,6 +26,9 @@ view color accidental =
                     [ class "text-red-700" ]
     in
     case accidental of
+        Natural ->
+            Html.text "-"
+
         Sharp2 ->
             node "x-diesis-2" attr []
 

--- a/src/Byzantine/Frequency.elm
+++ b/src/Byzantine/Frequency.elm
@@ -1,0 +1,104 @@
+module Byzantine.Frequency exposing
+    ( Frequency(..), unwrap
+    , PitchStandard(..), pitchStandardToString
+    , frequency, toPitchPosition
+    )
+
+{-| Frequency-related types and functions for Byzantine music.
+
+
+# Frequency
+
+@docs Frequency, unwrap
+
+
+# Pitch Standard
+
+@docs PitchStandard, pitchStandardToString
+
+
+# Calculations
+
+@docs frequency, toPitchPosition
+
+-}
+
+import Byzantine.Register as Register exposing (Register)
+
+
+{-| Frequency represented in Hz
+-}
+type Frequency
+    = Frequency Float
+
+
+{-| Extract the float value from a Frequency type
+-}
+unwrap : Frequency -> Float
+unwrap (Frequency frequency_) =
+    frequency_
+
+
+{-| Pitch standard for frequency. Ni = 256 Hz is the default standard, but the
+slightly higher Ke = 440 Hz is available to align with the A440 western
+classical standard.
+-}
+type PitchStandard
+    = Ni256
+    | Ke440
+
+
+{-| Convert a PitchStandard to a String representation
+-}
+pitchStandardToString : PitchStandard -> String
+pitchStandardToString pitchStandard =
+    case pitchStandard of
+        Ni256 ->
+            "Ni256"
+
+        Ke440 ->
+            "Ke440"
+
+
+{-| Di is used as a fixed point of reference. Returns the frequency in Hz for Di
+based on the given pitch standard.
+
+  - Ni256: Di = 384.0 Hz (based on Ni = 256 Hz)
+  - Ke440: Di = 391.995 Hz (based on Ke = 440 Hz)
+
+-}
+diFrequency : PitchStandard -> Float
+diFrequency pitchStandard =
+    case pitchStandard of
+        Ni256 ->
+            384.0
+
+        Ke440 ->
+            391.995
+
+
+{-| Calculate frequency relative to a fixed pitch for Natural Di, according to
+the given pitch standard and register.
+
+Takes a pitch position in moria and converts it to a frequency in Hz. The pitch
+position is relative to Natural Di at position 84.
+
+-}
+frequency : PitchStandard -> Register -> Int -> Frequency
+frequency pitchStandard register pitchPos =
+    let
+        position =
+            toFloat (pitchPos - 84)
+    in
+    2 ^ (position / 72) * diFrequency pitchStandard * Register.factor register |> Frequency
+
+
+{-| For a given frequency (in Hz), evaluate the pitch position in moria relative
+to a fixed position of Natural Di of 84.
+
+This is the inverse operation of the `frequency` function.
+
+-}
+toPitchPosition : PitchStandard -> Register -> Frequency -> Float
+toPitchPosition pitchStandard register (Frequency frequency_) =
+    72 * logBase 2 (frequency_ / (diFrequency pitchStandard * Register.factor register)) + 84

--- a/src/Byzantine/Pitch.elm
+++ b/src/Byzantine/Pitch.elm
@@ -5,9 +5,7 @@ module Byzantine.Pitch exposing
     , unwrapDegree, unwrapAccidental
     , isInflected, isValidInflection, toString
     , pitchPosition, pitchPositions
-    , Frequency(..), frequency, frequencyToPitchPosition, unwrapFrequency
-    , PitchStandard(..), pitchStandardToString
-    , Register(..), registerToString
+    , getPitchFrequency
     , Interval, intervals, intervalsFrom, getInterval
     )
 
@@ -51,17 +49,7 @@ attractions and inflections.
 
 # Frequency
 
-@docs Frequency, frequency, frequencyToPitchPosition, unwrapFrequency
-
-
-## PitchStandard
-
-@docs PitchStandard, pitchStandardToString
-
-
-## Register
-
-@docs Register, registerToString
+@docs getPitchFrequency
 
 
 # Intervals
@@ -73,6 +61,8 @@ attractions and inflections.
 import Array exposing (Array)
 import Byzantine.Accidental as Accidental exposing (Accidental)
 import Byzantine.Degree as Degree exposing (Degree)
+import Byzantine.Frequency as Frequency
+import Byzantine.Register as Register
 import Byzantine.Scale as Scale exposing (Scale(..))
 import Maybe.Extra
 import Result exposing (Result)
@@ -395,93 +385,12 @@ hardChromaticPitchPositions =
     Array.fromList [ 0, 12, 18, 38, 42, 54, 60, 80, 84, 96, 102, 122, 126, 136, 144 ]
 
 
-
--- FREQUENCY
-
-
-{-| Pitch standard for frequency. Ni = 256 Hz is the default standard, but the
-slightly higher Ke = 440 Hz is available to align with the A440 western
-classical standard.
+{-| Calculate frequency for a pitch using the given pitch standard and register.
 -}
-type PitchStandard
-    = Ni256
-    | Ke440
-
-
-pitchStandardToString : PitchStandard -> String
-pitchStandardToString pitchStandard =
-    case pitchStandard of
-        Ni256 ->
-            "Ni256"
-
-        Ke440 ->
-            "Ke440"
-
-
-{-| Di is used as a fixed point of reference.
--}
-diFrequency : PitchStandard -> Float
-diFrequency pitchStandard =
-    case pitchStandard of
-        Ni256 ->
-            384.0
-
-        Ke440 ->
-            391.995
-
-
-type Register
-    = Treble
-    | Bass
-
-
-registerToString : Register -> String
-registerToString register =
-    case register of
-        Treble ->
-            "Treble"
-
-        Bass ->
-            "Bass"
-
-
-registerFactor : Register -> Float
-registerFactor register =
-    case register of
-        Treble ->
-            1.0
-
-        Bass ->
-            0.5
-
-
-type Frequency
-    = Frequency Float
-
-
-{-| Frequency relative to a fixed pitch for Natural Di, according to the given pitch
-standard and register.
--}
-frequency : PitchStandard -> Register -> Scale -> Pitch -> Frequency
-frequency pitchStandard register scale pitch =
-    let
-        position =
-            toFloat (pitchPosition scale pitch - 84)
-    in
-    2 ^ (position / 72) * diFrequency pitchStandard * registerFactor register |> Frequency
-
-
-{-| For a given frequency (in Hz), evaluate the pitch position in moria relative
-to a fixed position of Natural Di of 84.
--}
-frequencyToPitchPosition : PitchStandard -> Register -> Frequency -> Float
-frequencyToPitchPosition pitchStandard register (Frequency frequency_) =
-    72 * logBase 2 (frequency_ / (diFrequency pitchStandard * registerFactor register)) + 84
-
-
-unwrapFrequency : Frequency -> Float
-unwrapFrequency (Frequency frequency_) =
-    frequency_
+getPitchFrequency : Frequency.PitchStandard -> Register.Register -> Scale -> Pitch -> Frequency.Frequency
+getPitchFrequency pitchStandard register scale pitch =
+    pitchPosition scale pitch
+        |> Frequency.frequency pitchStandard register
 
 
 

--- a/src/Byzantine/Register.elm
+++ b/src/Byzantine/Register.elm
@@ -1,0 +1,28 @@
+module Byzantine.Register exposing (Register(..), factor, toString)
+
+
+type Register
+    = Treble
+    | Bass
+
+
+toString : Register -> String
+toString register =
+    case register of
+        Treble ->
+            "Treble"
+
+        Bass ->
+            "Bass"
+
+
+{-| Factor by which to adjust a frequency based on register
+-}
+factor : Register -> Float
+factor register =
+    case register of
+        Treble ->
+            1.0
+
+        Bass ->
+            0.5

--- a/src/Main.elm
+++ b/src/Main.elm
@@ -3,7 +3,7 @@ module Main exposing (main)
 import Browser
 import Browser.Dom as Dom
 import Browser.Events
-import Byzantine.Pitch exposing (Frequency(..))
+import Byzantine.Frequency exposing (Frequency(..))
 import Model exposing (Model)
 import Ports
 import Task

--- a/src/Model.elm
+++ b/src/Model.elm
@@ -18,7 +18,7 @@ module Model exposing
 -}
 
 import Byzantine.Degree exposing (Degree(..))
-import Byzantine.Pitch exposing (Frequency)
+import Byzantine.Frequency exposing (Frequency)
 import Byzantine.Scale exposing (Scale(..))
 import Model.AudioSettings as AudioSettings exposing (AudioSettings)
 import Model.LayoutData as LayoutData exposing (LayoutData)

--- a/src/Model/AudioSettings.elm
+++ b/src/Model/AudioSettings.elm
@@ -13,7 +13,8 @@ module Model.AudioSettings exposing
 -}
 
 import Byzantine.Degree exposing (Degree(..))
-import Byzantine.Pitch exposing (PitchStandard(..), Register(..))
+import Byzantine.Frequency exposing (PitchStandard(..))
+import Byzantine.Register exposing (Register(..))
 
 
 type alias AudioSettings =

--- a/src/Model/PitchSpaceData.elm
+++ b/src/Model/PitchSpaceData.elm
@@ -116,6 +116,9 @@ type alias PitchSpaceData =
 primitives or singletons in here, we will need to construct targeted updates
 that preserve referential equality for values that don't change. Targeted
 updates wouldn't be a bad idea for performance, anyway.
+
+TODO: need to take the appliedAccidentals into account.
+
 -}
 init : LayoutData -> ModeSettings -> PitchState -> PitchSpaceData
 init layoutData modeSettings pitchState =
@@ -577,3 +580,20 @@ canBeSelectedAsIson indicator =
 
         _ ->
             False
+
+
+
+-- PITCH BUTTON CLICKS
+
+
+{-| Okay, new strategy. Rather than passing in the information needed to
+determine the specific Msg to be triggered by clicking on a pitch button,
+instead, just pass in whether or not the button can be clicked, or whether it is
+highlighted (which also means it can be clicked). The determination of what
+updates to the model are needed should happen entirely within the update
+function.
+-}
+type ClickEligibility
+    = Clickable
+    | Disabled
+    | Highlighted

--- a/src/Model/PitchState.elm
+++ b/src/Model/PitchState.elm
@@ -14,22 +14,27 @@ module Model.PitchState exposing
 import Byzantine.Accidental exposing (Accidental)
 import Byzantine.Degree exposing (Degree)
 import Byzantine.Pitch as Pitch exposing (Pitch)
+import Model.DegreeDataDict as DegreeDataDict exposing (DegreeDataDict)
 import Movement exposing (Movement)
 
 
 type alias PitchState =
-    { currentPitch : Maybe Pitch
+    { currentDegree : Maybe Degree
+    , currentPitch : Maybe Pitch
     , ison : IsonStatus
     , proposedAccidental : Maybe Accidental
+    , appliedAccidentals : DegreeDataDict (Maybe Accidental)
     , proposedMovement : Movement
     }
 
 
 initialPitchState : PitchState
 initialPitchState =
-    { currentPitch = Nothing
+    { currentDegree = Nothing
+    , currentPitch = Nothing
     , ison = NoIson
     , proposedAccidental = Nothing
+    , appliedAccidentals = DegreeDataDict.init (always Nothing)
     , proposedMovement = Movement.None
     }
 

--- a/src/Styles.elm
+++ b/src/Styles.elm
@@ -161,11 +161,11 @@ borderRounded =
     class "border border-gray-300 rounded-md"
 
 
-{-| `class "bg-gray-200 my-2 py-1 px-3 rounded-md"`
+{-| `class "bg-gray-200 hover:bg-gray-300 py-1 px-3 rounded-md cursor-pointer"`
 -}
 buttonClass : Html.Attribute msg
 buttonClass =
-    class "bg-gray-200 hover:bg-gray-300 my-2 py-1 px-3 rounded-md cursor-pointer"
+    class "bg-gray-200 hover:bg-gray-300 py-1 px-3 rounded-md cursor-pointer"
 
 
 {-| `class "transition-all duration-800"`

--- a/src/Update.elm
+++ b/src/Update.elm
@@ -4,7 +4,9 @@ import Array
 import Browser.Dom as Dom
 import Byzantine.Accidental as Accidental exposing (Accidental)
 import Byzantine.Degree as Degree exposing (Degree(..))
-import Byzantine.Pitch as Pitch exposing (Frequency(..), Pitch, PitchStandard, Register)
+import Byzantine.Frequency exposing (Frequency(..), PitchStandard)
+import Byzantine.Pitch as Pitch exposing (Pitch)
+import Byzantine.Register exposing (Register)
 import Byzantine.Scale exposing (Scale)
 import Maybe.Extra as Maybe
 import Model exposing (Modal, Model)

--- a/src/View.elm
+++ b/src/View.elm
@@ -1,6 +1,6 @@
 module View exposing (view)
 
-import Byzantine.Accidental as Accidental exposing (Accidental)
+import Byzantine.Accidental as Accidental
 import Byzantine.ByzHtml.Accidental as Accidental
 import Byzantine.ByzHtml.Martyria as Martyria
 import Byzantine.Degree as Degree exposing (Degree(..))
@@ -381,7 +381,6 @@ viewControls audioSettings modeSettings pitchState detectedPitch =
                     [ lazy isonButton pitchState.ison
                     , lazy viewIson (PitchState.ison pitchState.ison)
                     , lazy viewCurrentPitch pitchState.currentPitch
-                    , lazy viewAccidentalButtons pitchState.proposedAccidental
                     , lazy gainInput audioSettings
                     ]
         ]
@@ -411,6 +410,7 @@ isonButton : IsonStatus -> Html Msg
 isonButton ison =
     button
         [ Styles.buttonClass
+        , class "my-2"
         , id "select-ison-button"
         , onClick
             (SetIson
@@ -474,47 +474,11 @@ viewCurrentPitch pitch =
         ]
 
 
-viewAccidentalButtons : Maybe Accidental -> Html Msg
-viewAccidentalButtons maybeAccidental =
-    Html.fieldset
-        [ Styles.borderRounded
-        , class "px-2 pb-1 mb-2"
-        , class "flex flex-row flex-wrap gap-2 mt-2"
-        ]
-        (Html.legend [ class "px-1" ] [ Html.text "Accidental" ]
-            :: List.map (viewAccidentalButton maybeAccidental) Accidental.all
-        )
-
-
-viewAccidentalButton : Maybe Accidental -> Accidental -> Html Msg
-viewAccidentalButton proposedAccidental accidental =
-    let
-        isCurrent =
-            proposedAccidental == Just accidental
-    in
-    button
-        [ Styles.buttonClass
-        , class "text-3xl min-w-12"
-        , classList
-            [ ( "text-blue-700 border-2 border-blue-700", isCurrent )
-            , ( "border-2 border-transparent", not isCurrent )
-            ]
-        , onClick
-            (if isCurrent then
-                SelectProposedAccidental Nothing
-
-             else
-                SelectProposedAccidental (Just accidental)
-            )
-        ]
-        [ Accidental.view Accidental.InheritColor accidental ]
-
-
 clearButton : Msg -> Html Msg
 clearButton msg =
     button
         [ Styles.buttonClass
-        , class "mx-2"
+        , class "my-2 mx-2"
         , onClick msg
         ]
         [ text "clear" ]
@@ -533,7 +497,7 @@ gainInput { gain } =
     div []
         [ button
             [ Styles.buttonClass
-            , class "w-24 mr-4"
+            , class "w-24 my-2 mr-4"
             , onClick msg
             ]
             [ text buttonText ]

--- a/src/View.elm
+++ b/src/View.elm
@@ -4,9 +4,11 @@ import Byzantine.Accidental as Accidental
 import Byzantine.ByzHtml.Accidental as Accidental
 import Byzantine.ByzHtml.Martyria as Martyria
 import Byzantine.Degree as Degree exposing (Degree(..))
+import Byzantine.Frequency as Frequency exposing (Frequency, PitchStandard(..))
 import Byzantine.IntervalCharacter exposing (..)
 import Byzantine.Martyria as Martyria
-import Byzantine.Pitch as Pitch exposing (Frequency, Pitch, PitchStandard(..), Register(..))
+import Byzantine.Pitch as Pitch exposing (Pitch)
+import Byzantine.Register as Register exposing (Register(..))
 import Byzantine.Scale as Scale exposing (Scale(..))
 import Copy
 import Html exposing (Html, button, datalist, div, h1, h2, input, main_, p, span, text)
@@ -98,11 +100,11 @@ chantEngineNode : AudioSettings -> Scale -> Maybe Pitch -> Maybe Pitch -> Html m
 chantEngineNode audioSettings scale currentPitch currentIson =
     let
         frequency pitch =
-            Pitch.frequency audioSettings.pitchStandard
+            Pitch.getPitchFrequency audioSettings.pitchStandard
                 audioSettings.playbackRegister
                 scale
                 pitch
-                |> Pitch.unwrapFrequency
+                |> Frequency.unwrap
                 |> String.fromFloat
     in
     Html.node "chant-engine"
@@ -234,7 +236,7 @@ layoutRadioConfig =
 
 registerRadioConfig : String -> (Register -> Msg) -> RadioFieldset.Config Register Msg
 registerRadioConfig legendText onSelect =
-    { itemToString = Pitch.registerToString
+    { itemToString = Register.toString
     , legendText = legendText
     , onSelect = onSelect
     , options = [ Treble, Bass ]
@@ -254,7 +256,7 @@ responsivenessRadioConfig =
 
 pitchStandardRadioConfig : RadioFieldset.Config PitchStandard Msg
 pitchStandardRadioConfig =
-    { itemToString = Pitch.pitchStandardToString
+    { itemToString = Frequency.pitchStandardToString
     , legendText = "Pitch Standard"
     , onSelect = SetPitchStandard
     , options = [ Ni256, Ke440 ]

--- a/src/View/PitchSpace.elm
+++ b/src/View/PitchSpace.elm
@@ -9,9 +9,10 @@ import Byzantine.ByzHtml.Accidental as Accidental
 import Byzantine.ByzHtml.Interval as ByzHtmlInterval
 import Byzantine.ByzHtml.Martyria as ByzHtmlMartyria
 import Byzantine.Degree as Degree exposing (Degree)
+import Byzantine.Frequency as Frequency exposing (Frequency)
 import Byzantine.IntervalCharacter as IntervalCharacter
 import Byzantine.Martyria as Martyria
-import Byzantine.Pitch as Pitch exposing (Frequency, Interval, Pitch, PitchString)
+import Byzantine.Pitch as Pitch exposing (Interval, Pitch, PitchString)
 import Html exposing (Html, button, div, li, span, text)
 import Html.Attributes as Attr exposing (class, classList)
 import Html.Attributes.Extra as Attr exposing (attributeMaybe)
@@ -297,7 +298,7 @@ viewPitchIndicator : PitchSpaceData -> AudioSettings -> Frequency -> Html Msg
 viewPitchIndicator pitchSpaceData { pitchStandard, listenRegister, responsiveness } detectedPitch =
     let
         detectedPitchInMoria =
-            Pitch.frequencyToPitchPosition pitchStandard listenRegister detectedPitch
+            Frequency.toPitchPosition pitchStandard listenRegister detectedPitch
 
         position =
             case PitchSpaceData.displayToLayout pitchSpaceData.display of

--- a/src/View/PitchSpace.elm
+++ b/src/View/PitchSpace.elm
@@ -14,7 +14,7 @@ import Byzantine.Martyria as Martyria
 import Byzantine.Pitch as Pitch exposing (Frequency, Interval, Pitch, PitchString)
 import Html exposing (Html, button, div, li, span, text)
 import Html.Attributes as Attr exposing (class, classList)
-import Html.Attributes.Extra as Attr
+import Html.Attributes.Extra as Attr exposing (attributeMaybe)
 import Html.Events exposing (onClick, onFocus, onMouseEnter, onMouseLeave)
 import Html.Extra exposing (viewIf, viewIfLazy, viewMaybe)
 import Html.Lazy
@@ -599,12 +599,13 @@ pitchButton pitchString isCurrentDegree display isonStatusIndicator pitchPositio
             canBeSelectedAsIson || Maybe.unwrap False Pitch.isInflected decodedPitchToSelect
     in
     button
-        [ onClick <|
-            if canBeSelectedAsIson then
-                SetIson (Maybe.unwrap NoIson Selected decodedDegree)
+        [ attributeMaybe (\degree -> onClick (PitchButtonClicked degree)) decodedDegree
 
-            else
-                SelectPitch decodedPitchToSelect Nothing
+        -- onClick <|
+        --     if canBeSelectedAsIson then
+        --         SetIson (Maybe.unwrap NoIson Selected decodedDegree)
+        --     else
+        --         SelectPitch decodedPitchToSelect Nothing
         , pitchButtonSizeClass
         , class "rounded-full hover:z-20 cursor-pointer relative pb-8"
         , Styles.transition
@@ -737,8 +738,6 @@ pitchElementPosition target display pitchPositions positionWithinRange scalingFa
 -- ACCIDENTAL BUTTONS
 
 
-{-| TODO: need some sort of "natural" button here.
--}
 viewAccidentalButtons : Display -> Maybe Accidental -> Html Msg
 viewAccidentalButtons display maybeAccidental =
     div
@@ -764,7 +763,11 @@ viewAccidentalButtons display maybeAccidental =
         ]
 
 
-{-| TODO: new Msg
+{-| TODO: new Msg.
+
+Also, there appear to be display variants we might be able to use
+that might look better in this context.
+
 -}
 viewAccidentalButton : Maybe Accidental -> Accidental -> Html Msg
 viewAccidentalButton proposedAccidental accidental =

--- a/tests/Tests.elm
+++ b/tests/Tests.elm
@@ -148,6 +148,9 @@ accidentalBuilder =
                     Flat2 :: accidentals |> next
 
                 Just Flat2 ->
+                    Natural :: accidentals |> next
+
+                Just Natural ->
                     Sharp2 :: accidentals |> next
 
                 Just Sharp2 ->


### PR DESCRIPTION
To support pitch tracking to match inflected pitches, it is necessary to decouple an applied accidental from the current pitch. This establishes an "appliedAccidentals" DegreeDataDict on the pitch state model so that multiple accidentals can be applied at once, independently of the currently selected degree that is being played.