### PR TITLE
Visible range refactor

### DIFF
--- a/src/View/PitchSpace.elm
+++ b/src/View/PitchSpace.elm
@@ -331,10 +331,10 @@ viewPitchIndicator pitchSpaceData { pitchStandard, listenRegister, responsivenes
         position =
             case PitchSpaceData.displayToLayout pitchSpaceData.display of
                 Vertical ->
-                    Styles.top (pitchSpaceData.scalingFactor * (toFloat pitchSpaceData.visibleRangeEndPosition - detectedPitchInMoria))
+                    Styles.top (pitchSpaceData.scalingFactor * (toFloat pitchSpaceData.visibleRange.endPosition - detectedPitchInMoria))
 
                 Horizontal ->
-                    Styles.left (pitchSpaceData.scalingFactor * (detectedPitchInMoria - toFloat pitchSpaceData.visibleRangeStartPosition))
+                    Styles.left (pitchSpaceData.scalingFactor * (detectedPitchInMoria - toFloat pitchSpaceData.visibleRange.startPosition))
 
         offset =
             -- TODO: there's functionality here to build out


### PR DESCRIPTION
Minor bug fix: because interval visibility was being calculated from pitch position of the visible range rather than by degree index, the visibility would be off in some edge cases (i.e., a proposed sharp applied to the bottom interval of the visible range), resulting in an additional interval being pulled into the visible range. This refactor fixes that bug, while also consolidating the visible range data into single record.