### PR TITLE
Safari

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## v.1.5.0 (2026-04-16)
+### Added
+ - Text description of the range setting (improved feedback for WebKit browsers)
+### Changed
+ - Tweaks to viewport recalculation following header toggle
+### Fixed
+ - Anchor positioning and minimum size for accidentals on pitch buttons fixes hiding of applied accidentals on Webkit browsers
+
 ## v.1.4.3 (2026-04-13)
 ### Added
  - Χριστὸς ἀνέστη!

--- a/src/Update.elm
+++ b/src/Update.elm
@@ -21,6 +21,7 @@ import Model.ModeSettings exposing (ModeSettings)
 import Model.PitchSpaceData as PitchSpaceData exposing (PitchSpaceData)
 import Model.PitchState as PitchState exposing (IsonStatus(..), PitchState, ProposedAccidental(..))
 import Movement exposing (Movement)
+import Process
 import Remote.AboutCopy exposing (AboutCopy)
 import Remote.Changelog exposing (Changelog)
 import RemoteData
@@ -65,7 +66,7 @@ update : Msg -> Model -> ( Model, Cmd Msg )
 update msg model =
     case msg of
         NoOp ->
-            ( model, Task.perform GotViewport Dom.getViewport )
+            ( model, getViewport )
 
         ChangelogReceived result ->
             ( updateRemote
@@ -113,10 +114,7 @@ update msg model =
 
         ViewportResize _ _ ->
             ( model
-            , Cmd.batch
-                [ Task.perform GotViewport Dom.getViewport
-                , Task.perform GotViewport Dom.getViewport
-                ]
+            , getViewport
             )
 
         PitchButtonClicked degree ->
@@ -152,7 +150,7 @@ update msg model =
               }
                 |> updateAudioSettings (\audioSettings -> { audioSettings | audioMode = mode })
                 |> resetPitchSpaceData
-            , Task.perform GotViewport Dom.getViewport
+            , getViewport
             )
 
         SetGain gain ->
@@ -175,7 +173,7 @@ update msg model =
                 (\layoutData -> { layoutData | layoutSelection = layoutSelection })
                 model
                 |> resetPitchSpaceData
-            , Task.perform GotViewport Dom.getViewport
+            , getViewport
             )
 
         SetPitchStandard pitchStandard ->
@@ -252,7 +250,7 @@ update msg model =
 
         ToggleHeaderCollapsed ->
             ( { model | headerCollapsed = not model.headerCollapsed }
-            , Cmd.none
+            , Cmd.batch [ getViewportAfter 300, getViewportAfter 800 ]
             )
 
         ToggleMenu ->
@@ -923,3 +921,15 @@ handleModalSelection modal model =
 focus : String -> Cmd Msg
 focus id =
     Task.attempt DomResult (Dom.focus id)
+
+
+getViewport : Cmd Msg
+getViewport =
+    Task.perform GotViewport Dom.getViewport
+
+
+getViewportAfter : Float -> Cmd Msg
+getViewportAfter delay =
+    Process.sleep delay
+        |> Task.andThen (\_ -> Dom.getViewport)
+        |> Task.perform GotViewport

--- a/src/View.elm
+++ b/src/View.elm
@@ -369,7 +369,7 @@ rangeFieldset { rangeStart, rangeEnd } =
             Degree.indexOf degree |> String.fromInt
 
         row label id_ min max value msg =
-            div [ Styles.flexRow, class "align-center max-w-full flex-wrap" ]
+            div [ Styles.flexRow, class "align-center max-w-full flex-wrap mt-2" ]
                 [ Html.label
                     [ Attr.for id_
                     , class "w-14 mt-1"
@@ -407,6 +407,12 @@ rangeFieldset { rangeStart, rangeEnd } =
     in
     Html.fieldset [ Styles.borderRounded, class "px-2 pb-1 mb-2" ]
         [ Html.legend [ class "px-1" ] [ Html.text "Range" ]
+        , p []
+            [ span [ class "me-1" ] [ text "Display range" ]
+            , Degree.text rangeStart
+            , span [ class "mx-1" ] [ text "to" ]
+            , Degree.text rangeEnd
+            ]
         , row "From:" "range-start" GA maxLowerBound rangeStart SetRangeStart
         , row "To:" "range-end" minUpperBound Ga_ rangeEnd SetRangeEnd
         ]

--- a/src/View/Controls.elm
+++ b/src/View/Controls.elm
@@ -139,11 +139,11 @@ optionHeaderWrapper isOpen optionHeaderTextNodes icon =
             [ class "flex flex-col md:flex-row" ]
             [ case icon of
                 SvgIcon svg ->
-                    div [ class "mx-auto" ]
+                    div [ class "mx-auto self-center" ]
                         [ svg [ Svg.fill "grey", Svg.width "24" ] ]
 
                 ByzHtmlIcon html ->
-                    div [ class "text-neutral-500" ] [ html ]
+                    div [ class "text-neutral-500 self-center" ] [ html ]
             , div [ class "md:ml-2 text-xs md:text-base" ]
                 optionHeaderTextNodes
             ]

--- a/src/View/PitchSpace.elm
+++ b/src/View/PitchSpace.elm
@@ -674,6 +674,7 @@ pitchButton pitchString isCurrentDegree display pitchPositions shouldHighlight p
         ]
         [ button
             [ attributeMaybe (\degree -> onClick (PitchButtonClicked degree)) decodedDegree
+            , attributeMaybe (\degree -> Attr.id ("p_" ++ Degree.toString degree)) decodedDegree
             , pitchButtonSizeClass
             , class "pitch-button rounded-full hover:z-20 cursor-pointer pb-8"
             , classList

--- a/src/View/PitchSpace.elm
+++ b/src/View/PitchSpace.elm
@@ -656,6 +656,12 @@ pitchButton pitchString isCurrentDegree display pitchPositions shouldHighlight p
                 pitchPositions
                 positionWithinRange
                 scalingFactor
+
+        decodedAccidental =
+            Maybe.andThen Pitch.unwrapAccidental decodedPitch
+
+        accidentalId =
+            Maybe.map (\degree -> Degree.toString degree ++ "-accidental") decodedDegree
     in
     div
         [ class "pitch-button-wrapper"
@@ -682,7 +688,14 @@ pitchButton pitchString isCurrentDegree display pitchPositions shouldHighlight p
             [ Maybe.map2
                 (\scale pitch ->
                     ByzHtmlMartyria.viewWithAttributes
-                        [ Styles.left -3, Styles.top -3 ]
+                        ([ Styles.left -3, Styles.top -3 ]
+                            ++ (Maybe.map2
+                                    (\_ id -> [ Attr.attribute "aria-owns" id ])
+                                    decodedAccidental
+                                    accidentalId
+                                    |> Maybe.withDefault []
+                               )
+                        )
                         (Martyria.for scale (Pitch.unwrapDegree pitch))
                 )
                 decodedScale
@@ -691,10 +704,14 @@ pitchButton pitchString isCurrentDegree display pitchPositions shouldHighlight p
             ]
         , Html.Extra.viewMaybe
             (\accidental ->
-                span [ class "pitch-button-accidental" ]
+                span
+                    [ class "pitch-button-accidental"
+                    , attributeMaybe Attr.id accidentalId
+                    , Attr.attribute "aria-label" (Accidental.toString accidental ++ " moria")
+                    ]
                     [ ByzHtmlAccidental.view ByzHtmlAccidental.Red accidental ]
             )
-            (Maybe.andThen Pitch.unwrapAccidental decodedPitch)
+            decodedAccidental
         ]
 
 

--- a/src/View/PitchSpace.elm
+++ b/src/View/PitchSpace.elm
@@ -657,40 +657,44 @@ pitchButton pitchString isCurrentDegree display pitchPositions shouldHighlight p
                 positionWithinRange
                 scalingFactor
     in
-    button
-        [ attributeMaybe (\degree -> onClick (PitchButtonClicked degree)) decodedDegree
-        , pitchButtonSizeClass
-        , class "rounded-full hover:z-20 cursor-pointer relative pb-8"
+    div
+        [ class "pitch-button-wrapper"
         , Styles.transition
         , if PitchSpaceData.isVertical display then
             Styles.top position
 
           else
             Styles.left position
-        , classList
-            [ ( "bg-red-200 z-10", isCurrentDegree )
-            , ( "hover:text-green-700 bg-slate-200 hover:bg-slate-300 opacity-75 hover:opacity-90", not isCurrentDegree )
-
-            -- , ( "text-green-700 bg-slate-300 z-10", Movement.unwrapTargetPitch pitchState.proposedMovement == decodedPitch )
-            , ( "border-2 border-blue-700", shouldHighlight )
-            , ( "border-2 border-transparent", not shouldHighlight )
-            ]
         ]
-        [ Html.Extra.viewMaybe
+        [ button
+            [ attributeMaybe (\degree -> onClick (PitchButtonClicked degree)) decodedDegree
+            , pitchButtonSizeClass
+            , class "pitch-button rounded-full hover:z-20 cursor-pointer pb-8"
+            , classList
+                [ ( "bg-red-200 z-10", isCurrentDegree )
+                , ( "hover:text-green-700 bg-slate-200 hover:bg-slate-300 opacity-75 hover:opacity-90", not isCurrentDegree )
+
+                -- , ( "text-green-700 bg-slate-300 z-10", Movement.unwrapTargetPitch pitchState.proposedMovement == decodedPitch )
+                , ( "border-2 border-blue-700", shouldHighlight )
+                , ( "border-2 border-transparent", not shouldHighlight )
+                ]
+            ]
+            [ Maybe.map2
+                (\scale pitch ->
+                    ByzHtmlMartyria.viewWithAttributes
+                        [ Styles.left -3, Styles.top -3 ]
+                        (Martyria.for scale (Pitch.unwrapDegree pitch))
+                )
+                decodedScale
+                decodedPitch
+                |> Maybe.withDefault Html.Extra.nothing
+            ]
+        , Html.Extra.viewMaybe
             (\accidental ->
-                span [ class "absolute mt-2 md:mt-4", Styles.left 12 ]
+                span [ class "pitch-button-accidental" ]
                     [ ByzHtmlAccidental.view ByzHtmlAccidental.Red accidental ]
             )
             (Maybe.andThen Pitch.unwrapAccidental decodedPitch)
-        , Maybe.map2
-            (\scale pitch ->
-                ByzHtmlMartyria.viewWithAttributes
-                    [ Styles.left -3, Styles.top -3 ]
-                    (Martyria.for scale (Pitch.unwrapDegree pitch))
-            )
-            decodedScale
-            decodedPitch
-            |> Maybe.withDefault Html.Extra.nothing
         ]
 
 

--- a/src/main.css
+++ b/src/main.css
@@ -25,18 +25,21 @@
 .pitch-button-accidental {
     position: absolute;
     left: 12px;
-    top: 16px;
-    font-size: 1.25rem; /* text-xl: matches button font size */
+    top: 12px;
+    font-size: 1rem;
     min-width: 1em;
     min-height: 1em;
     z-index: 30;
-    /* Anchor positioning (Chrome 125+, Safari 26+, Firefox 147+).
-       If anchor() is unsupported, the browser skips these declarations
-       and the fallback left/top values above remain in effect. */
     @media (min-width: 640px) {
         font-size: 1.875rem; /* sm:text-3xl: matches button font size */
     }
+    /* Anchor positioning (Chrome 125+, Safari 26+, Firefox 147+).
+       If anchor() is unsupported, the browser skips these declarations
+       and the fallback left/top values above remain in effect. */
     position-anchor: --pitch-button-anchor;
-    left: calc(anchor(left) + 12px);
-    top: calc(anchor(top) + 16px);
+    left: calc(anchor(left) + 10px);
+    @media (min-width: 640px) {
+        left: calc(anchor(left) + 14px);
+    }
+    top: calc(anchor(top) + 12px);
 }

--- a/src/main.css
+++ b/src/main.css
@@ -1,14 +1,42 @@
 @import "tailwindcss";
 
-
 .font-greek {
-    font-family: 'Gentium Plus', serif;
+    font-family: "Gentium Plus", serif;
 }
 
 .font-heading {
-    font-family: 'IM Fell Double Pica';
+    font-family: "IM Fell Double Pica";
 }
 
 .font-serif {
-    font-family: 'Lora', serif;
+    font-family: "Lora", serif;
+}
+
+.pitch-button-wrapper {
+    position: relative;
+    anchor-scope: --pitch-button-anchor;
+    width: fit-content;
+}
+
+.pitch-button {
+    anchor-name: --pitch-button-anchor;
+}
+
+.pitch-button-accidental {
+    position: absolute;
+    left: 12px;
+    top: 16px;
+    font-size: 1.25rem; /* text-xl: matches button font size */
+    min-width: 1em;
+    min-height: 1em;
+    z-index: 30;
+    /* Anchor positioning (Chrome 125+, Safari 26+, Firefox 147+).
+       If anchor() is unsupported, the browser skips these declarations
+       and the fallback left/top values above remain in effect. */
+    @media (min-width: 640px) {
+        font-size: 1.875rem; /* sm:text-3xl: matches button font size */
+    }
+    position-anchor: --pitch-button-anchor;
+    left: calc(anchor(left) + 12px);
+    top: calc(anchor(top) + 16px);
 }

--- a/src/main.css
+++ b/src/main.css
@@ -30,6 +30,7 @@
     min-width: 1em;
     min-height: 1em;
     z-index: 30;
+    pointer-events: none;
     @media (min-width: 640px) {
         font-size: 1.875rem; /* sm:text-3xl: matches button font size */
     }


### PR DESCRIPTION
Enhancements for mobile, particularly Safari.

- Add a text description of the range setting (compensates for Safari not having good support for data labels)
- Improved viewport recalculation after header toggling
- Use anchor positioning for accidentals attached to pitch buttons (compensates for Safari rendering of button elements)