### PR TITLE
offer users an appropriate paschal greeting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v.1.4.3 (2026-04-13)
+### Added
+ - Χριστὸς ἀνέστη!
+
 ## v.1.4.2 (2026-03-28)
 ### Changed
  - Minor refactor for collapsible items

--- a/elm.json
+++ b/elm.json
@@ -4,6 +4,7 @@
   "elm-version": "0.19.1",
   "dependencies": {
     "direct": {
+      "akheron/elm-easter": "1.1.0",
       "edgerunner/elm-tuple-trio": "1.0.0",
       "elm/browser": "1.0.2",
       "elm/core": "1.0.5",

--- a/src/Main.elm
+++ b/src/Main.elm
@@ -4,6 +4,7 @@ import Browser
 import Browser.Dom as Dom
 import Browser.Events
 import Byzantine.Frequency exposing (Frequency(..))
+import Date exposing (Date)
 import Json.Decode as Decode exposing (Decoder, Value)
 import Model exposing (Model)
 import Model.DeviceInfo as DeviceInfo exposing (DeviceInfo)
@@ -31,11 +32,11 @@ main =
 init : Value -> ( Model, Cmd Msg )
 init flags =
     let
-        { deviceInfo, viewport } =
+        { deviceInfo, viewport, currentDate } =
             Decode.decodeValue flagsDecoder flags
                 |> Result.withDefault defaultFlags
     in
-    ( Model.init deviceInfo viewport
+    ( Model.init deviceInfo viewport currentDate
     , Task.perform GotViewport Dom.getViewport
     )
 
@@ -61,6 +62,7 @@ subscriptions _ =
 type alias Flags =
     { deviceInfo : DeviceInfo
     , viewport : { width : Float, height : Float }
+    , currentDate : Maybe Date
     }
 
 
@@ -68,14 +70,30 @@ defaultFlags : Flags
 defaultFlags =
     { deviceInfo = DeviceInfo.default
     , viewport = { width = 0, height = 256 }
+    , currentDate = Nothing
     }
 
 
 flagsDecoder : Decoder Flags
 flagsDecoder =
-    Decode.map2 Flags
+    Decode.map3 Flags
         (Decode.field "deviceInfo" DeviceInfo.decoder)
         (Decode.field "viewport" viewportDecoder)
+        (Decode.field "currentDate" dateDecoder)
+
+
+dateDecoder : Decoder (Maybe Date)
+dateDecoder =
+    Decode.string
+        |> Decode.andThen
+            (\str ->
+                case Date.fromIsoString (String.left 10 str) of
+                    Ok date ->
+                        Decode.succeed (Just date)
+
+                    Err _ ->
+                        Decode.succeed Nothing
+            )
 
 
 viewportDecoder : Decoder { width : Float, height : Float }

--- a/src/Main.elm
+++ b/src/Main.elm
@@ -85,14 +85,14 @@ flagsDecoder =
 dateDecoder : Decoder (Maybe Date)
 dateDecoder =
     Decode.string
-        |> Decode.andThen
+        |> Decode.map
             (\str ->
                 case Date.fromIsoString (String.left 10 str) of
                     Ok date ->
-                        Decode.succeed (Just date)
+                        Just date
 
                     Err _ ->
-                        Decode.succeed Nothing
+                        Nothing
             )
 
 

--- a/src/Model.elm
+++ b/src/Model.elm
@@ -24,8 +24,10 @@ module Model exposing
 -}
 
 import Byzantine.DetectedPitch exposing (DetectedPitch)
+import Date exposing (Date)
 import Http
 import Model.AudioSettings as AudioSettings exposing (AudioSettings)
+import Model.CalendarInfo as CalendarInfo exposing (CalendarInfo)
 import Model.ControlsMenu as ControlsMenu exposing (OpenControlMenus)
 import Model.DeviceInfo exposing (DeviceInfo)
 import Model.LayoutData as LayoutData exposing (LayoutData)
@@ -40,7 +42,7 @@ import Time
 
 type alias Model =
     { audioSettings : AudioSettings
-    , remote : Remote
+    , calendar : CalendarInfo
     , detectedPitch : Maybe { detectedPitch : DetectedPitch, timestamp : Time.Posix }
     , deviceInfo : DeviceInfo
     , headerIsOpen : Bool
@@ -51,6 +53,7 @@ type alias Model =
     , openControlMenus : OpenControlMenus
     , pitchSpaceData : PitchSpaceData
     , pitchState : PitchState
+    , remote : Remote
     }
 
 
@@ -60,17 +63,14 @@ type alias Remote =
     }
 
 
-init : DeviceInfo -> { width : Float, height : Float } -> Model
-init deviceInfo viewportDimensions =
+init : DeviceInfo -> { width : Float, height : Float } -> Maybe Date -> Model
+init deviceInfo viewportDimensions currentDate =
     let
         layoutData =
             LayoutData.init viewportDimensions
     in
     { audioSettings = AudioSettings.defaultAudioSettings
-    , remote =
-        { changelog = RemoteData.NotAsked
-        , aboutCopy = RemoteData.NotAsked
-        }
+    , calendar = CalendarInfo.init currentDate
     , detectedPitch = Nothing
     , deviceInfo = deviceInfo
     , headerIsOpen = True
@@ -85,6 +85,10 @@ init deviceInfo viewportDimensions =
             ModeSettings.initialModeSettings
             PitchState.initialPitchState
     , pitchState = PitchState.initialPitchState
+    , remote =
+        { changelog = RemoteData.NotAsked
+        , aboutCopy = RemoteData.NotAsked
+        }
     }
 
 

--- a/src/Model/CalendarInfo.elm
+++ b/src/Model/CalendarInfo.elm
@@ -1,0 +1,14 @@
+module Model.CalendarInfo exposing (CalendarInfo, init)
+
+import Date exposing (Date)
+
+
+type alias CalendarInfo =
+    { currentDate : Maybe Date
+    }
+
+
+init : Maybe Date -> CalendarInfo
+init currentDate =
+    { currentDate = currentDate
+    }

--- a/src/Model/CalendarInfo.elm
+++ b/src/Model/CalendarInfo.elm
@@ -1,14 +1,44 @@
 module Model.CalendarInfo exposing (CalendarInfo, init)
 
 import Date exposing (Date)
+import Easter
+import Maybe.Extra
 
 
 type alias CalendarInfo =
     { currentDate : Maybe Date
+    , isEastertide : Bool
     }
 
 
 init : Maybe Date -> CalendarInfo
 init currentDate =
     { currentDate = currentDate
+    , isEastertide = calculateIsEastertide currentDate
     }
+
+
+calculateIsEastertide : Maybe Date -> Bool
+calculateIsEastertide maybeCurrentDate =
+    Maybe.Extra.unwrap False checkDateInEastertidePeriod maybeCurrentDate
+
+
+checkDateInEastertidePeriod : Date -> Bool
+checkDateInEastertidePeriod currentDate =
+    let
+        paschaDate =
+            Easter.easter Easter.Orthodox (Date.year currentDate)
+
+        easterDate =
+            Date.fromCalendarDate paschaDate.year paschaDate.month paschaDate.day
+    in
+    dateIsInPaschalSeason currentDate easterDate
+
+
+dateIsInPaschalSeason : Date -> Date -> Bool
+dateIsInPaschalSeason currentDate paschaDate =
+    let
+        daysAfterEaster =
+            Date.diff Date.Days paschaDate currentDate
+    in
+    daysAfterEaster >= 0 && daysAfterEaster < 40

--- a/src/View.elm
+++ b/src/View.elm
@@ -19,6 +19,7 @@ import Json.Decode exposing (Decoder)
 import Maybe.Extra as Maybe
 import Model exposing (Modal(..), Model, Remote)
 import Model.AudioSettings as AudioSettings exposing (AudioSettings)
+import Model.CalendarInfo exposing (CalendarInfo)
 import Model.LayoutData as LayoutData exposing (Layout(..), LayoutData, LayoutSelection(..), layoutFor)
 import Model.ModeSettings exposing (ModeSettings)
 import Model.PitchState as PitchState
@@ -47,7 +48,7 @@ view model =
                     (PitchState.ison model.pitchState.ison)
             )
         , lazy2 backdrop model.menuOpen model.modal
-        , lazy header model.headerIsOpen
+        , lazy2 header model.calendar model.headerIsOpen
         , lazy5 viewModal model.audioSettings model.layoutData model.modeSettings model.remote model.modal
 
         -- , viewIf LayoutData.showSpacing (div [ class "text-center" ] [ text "|" ])
@@ -127,8 +128,8 @@ chantEngineNode audioSettings scale currentPitch currentIson =
 Caret points down when expanded, rotates 180° when collapsed.
 
 -}
-header : Bool -> Html Msg
-header headerIsOpen =
+header : CalendarInfo -> Bool -> Html Msg
+header calendarInfo headerIsOpen =
     Html.header
         [ Styles.flexRowCentered
         , Styles.transition
@@ -160,6 +161,13 @@ header headerIsOpen =
                     [ text "ByzanTone" ]
                 , p [ class "font-serif text-center" ]
                     [ text "A tool for learning the pitches and intervals of Byzantine chant." ]
+                , viewIf calendarInfo.isEastertide
+                    (p [ class "font-serif text-center" ]
+                        [ span [ class "font-greek" ] [ text "Χριστὸς ἀνέστη" ]
+                        , text " – "
+                        , text "Christ is risen!"
+                        ]
+                    )
 
                 -- , viewIf model.layoutData.showSpacing (p [ class "text-center" ] [ text "|" ])
                 ]

--- a/src/index.html
+++ b/src/index.html
@@ -68,6 +68,7 @@
                 flags: {
                     deviceInfo: getDeviceInfo(),
                     viewport: getViewportInfo(),
+                    currentDate: new Date().toISOString(),
                 },
             });
 


### PR DESCRIPTION
Some generous soul went through the trouble of making an Elm package for calculating the date of Easter, and they were thoughtful enough to include the Orthodox calendar as well as the Catholic. So why not use it to wish users Χριστὸς ἀνέστη during Paschaltide? This should also provide a framework for other feast-appropriate greetings.